### PR TITLE
Upgrade netcore3 sample api to netcoreapp3.1

### DIFF
--- a/build/deployment.yml
+++ b/build/deployment.yml
@@ -20,6 +20,13 @@ pool:
   vmImage: ubuntu-18.04
 
 steps:
+  ## Install dotnetcore 3.1
+  - task: UseDotNet@2
+    inputs:
+      version: "3.1.x"
+      packageType: sdk
+    displayName: "Install .NET Core 3.1.x"
+
   ## Performa package restore
   - task: DotNetCoreCLI@2
     inputs:

--- a/build/pull-request.yml
+++ b/build/pull-request.yml
@@ -14,6 +14,13 @@ pool:
   vmImage: ubuntu-18.04
 
 steps:
+  ## Install dotnetcore 3.1
+  - task: UseDotNet@2
+    inputs:
+      version: "3.1.x"
+      packageType: sdk
+    displayName: "Install .NET Core 3.1.x"
+
   ## Nuget Package Restore
   - task: DotNetCoreCLI@2
     inputs:

--- a/src/starwars/starwars-api30/starwars-api30.csproj
+++ b/src/starwars/starwars-api30/starwars-api30.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;NU1603</NoWarn>
     <RootNamespace>GraphQL.AspNet.StarWarsAPI30</RootNamespace>


### PR DESCRIPTION
Updated the `starwars-api30` sample project that is included as part of the master solution to target `netcoreapp3.1` in accordance with the newly released 3.1 core framework sdk.