### PR TITLE
CORS support in star wars projects (Dev -> Master )

### DIFF
--- a/src/starwars/starwars-api22/Startup.cs
+++ b/src/starwars/starwars-api22/Startup.cs
@@ -44,6 +44,21 @@ namespace GraphQL.AspNet.StarWarsAPI
             services.AddSingleton<StarWarsDataRepository>();
             services.AddScoped<IStarWarsDataService, StarWarsDataService>();
 
+            // apply an unrestricted cors policy for the demo services
+            // to allow use on many of the tools for testing (graphiql, altair etc.)
+            // Do not do this in production
+            services.AddCors(options =>
+            {
+                options.AddPolicy(
+                    "_allOrigins",
+                    builder =>
+                    {
+                        builder.AllowAnyOrigin()
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                    });
+            });
+
             // ----------------------------------------------------------
             // Add the MVC middleware
             // ----------------------------------------------------------
@@ -84,6 +99,8 @@ namespace GraphQL.AspNet.StarWarsAPI
         public void Configure(IApplicationBuilder application)
         {
             application.AddStarWarsStartedMessageToConsole();
+
+            application.UseCors("_allOrigins");
 
             application.UseMvc();
 

--- a/src/starwars/starwars-api30/Startup.cs
+++ b/src/starwars/starwars-api30/Startup.cs
@@ -34,6 +34,21 @@ namespace GraphQL.AspNet.StarWarsAPI30
             services.AddSingleton<StarWarsDataRepository>();
             services.AddScoped<IStarWarsDataService, StarWarsDataService>();
 
+            // apply an unrestricted cors policy for the demo services
+            // to allow use on many of the tools for testing (graphiql, altair etc.)
+            // Do not do this in production
+            services.AddCors(options =>
+            {
+                options.AddPolicy(
+                    "_allOrigins",
+                    builder =>
+                    {
+                        builder.AllowAnyOrigin()
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                    });
+            });
+
             // ----------------------------------------------------------
             // Register GraphQL with the application
             // ----------------------------------------------------------
@@ -60,6 +75,7 @@ namespace GraphQL.AspNet.StarWarsAPI30
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+
             app.AddStarWarsStartedMessageToConsole();
 
             if (env.IsDevelopment())
@@ -69,7 +85,14 @@ namespace GraphQL.AspNet.StarWarsAPI30
 
             app.UseRouting();
 
+            app.UseCors("_allOrigins");
+
             app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
 
             // ************************************************************
             // Finalize the graphql setup by load the schema, build out the templates for all found graph types
@@ -77,11 +100,6 @@ namespace GraphQL.AspNet.StarWarsAPI30
             // be sure to register it after "UseAuthorization" if you require access to this.User
             // ************************************************************
             app.UseGraphQL();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
         }
     }
 }


### PR DESCRIPTION
**Related to:** https://github.com/graphql-aspnet/graphql-aspnet/pull/9

Due to recent updates in some browser tooling for graphql. Unrestricted CORS support was added to the default star wars projects to facilitate easily running the project locally while exploring, debugging or testing.  A warning indicating this is not a good practice for a production site was also included.