### PR TITLE
fix to editorconfig for proper line endings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
Fixed an issue with `.editorConfig` so that it denotes `LF` not `CRLF` as the line ending.  Should help with mac users using rider (which obeys the setting) with tools that may not auto adjust line endings before commits...resulting in erroneous file diffs.