### PR TITLE
Use invariant parsing for floating-point numbers

### DIFF
--- a/src/graphql-aspnet/Schemas/TypeSystem/Scalars/DecimalScalarType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Scalars/DecimalScalarType.cs
@@ -10,6 +10,7 @@
 namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
 {
     using System;
+    using System.Globalization;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Parsing.SyntaxNodes;
@@ -52,7 +53,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
         /// <returns>The final native value of the converted data.</returns>
         public override object Resolve(ReadOnlySpan<char> data)
         {
-            if (decimal.TryParse(data.ToString(), out var i))
+            if (decimal.TryParse(data.ToString(), NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var i))
                 return i;
 
             throw new UnresolvedValueException(data);

--- a/src/graphql-aspnet/Schemas/TypeSystem/Scalars/DoubleScalarType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Scalars/DoubleScalarType.cs
@@ -10,6 +10,7 @@
 namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
 {
     using System;
+    using System.Globalization;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Parsing.SyntaxNodes;
@@ -50,7 +51,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
         /// <returns>The final native value of the converted data.</returns>
         public override object Resolve(ReadOnlySpan<char> data)
         {
-            if (double.TryParse(data.ToString(), out var i))
+            if (double.TryParse(data.ToString(), NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var i))
                 return i;
 
             throw new UnresolvedValueException(data);

--- a/src/graphql-aspnet/Schemas/TypeSystem/Scalars/FloatScalarType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Scalars/FloatScalarType.cs
@@ -10,6 +10,7 @@
 namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
 {
     using System;
+    using System.Globalization;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Parsing.SyntaxNodes;
@@ -50,7 +51,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
         /// <returns>The final native value of the converted data.</returns>
         public override object Resolve(ReadOnlySpan<char> data)
         {
-            if (float.TryParse(data.ToString(), out var i))
+            if (float.TryParse(data.ToString(), NumberStyles.Any, NumberFormatInfo.InvariantInfo, out var i))
                 return i;
 
             throw new UnresolvedValueException(data);

--- a/src/tests/graphql-aspnet-tests/PlanGeneration/InputResolverGeneratorTests.cs
+++ b/src/tests/graphql-aspnet-tests/PlanGeneration/InputResolverGeneratorTests.cs
@@ -154,6 +154,7 @@ namespace GraphQL.AspNet.Tests.PlanGeneration
         }
 
         [TestCaseSource(nameof(_inputValueResolverTestCases_WithValidData))]
+        [SetCulture("en-US")]
         public void DefaultScalarValueResolvers(string expressionText, string inputText, object expectedOutput)
         {
             var generator = new InputResolverMethodGenerator(this.CreateSchema());
@@ -177,6 +178,13 @@ namespace GraphQL.AspNet.Tests.PlanGeneration
             var result = resolver.Resolve(inputValue);
 
             Assert.AreEqual(expectedOutput, result);
+        }
+
+        [TestCaseSource(nameof(_inputValueResolverTestCases_WithValidData))]
+        [SetCulture("de-DE")]
+        public void DefaultScalarValueResolvers_WithGermanCulture(string expressionText, string inputText, object expectedOutput)
+        {
+             DefaultScalarValueResolvers(expressionText, inputText, expectedOutput);
         }
 
         [TestCaseSource(nameof(_inputValueResolverTestCases_WithInvalidData))]


### PR DESCRIPTION
## Changes Made

The previous parsing of the floating-point numbers was culture-specific. This leads to issues with cultures that do not use the dot as decimal separator, e.g. `de-DE`.

By using `NumberFormatInfo.InvariantInfo` and `NumberStyles.Any`, this issue can be avoided.