### PR TITLE
Altered SubscriptionServerOptions property

### DIFF
--- a/src/graphql-aspnet-subscriptions/Apollo/ApolloSubscriptionServer{TSchema}.cs
+++ b/src/graphql-aspnet-subscriptions/Apollo/ApolloSubscriptionServer{TSchema}.cs
@@ -188,7 +188,7 @@ namespace GraphQL.AspNet.Apollo
                 _schema.Configuration.ExecutionOptions.EnableMetrics);
 
             var isAuthenticated = connection.User?.Identities.Any(x => x.IsAuthenticated) ?? false;
-            if (_serverOptions.RequiredAuthenticatedConnection && !isAuthenticated)
+            if (_serverOptions.AuthenticatedRequestsOnly && !isAuthenticated)
             {
                 await apolloClient.SendMessage(
                     new ApolloServerErrorMessage(

--- a/src/graphql-aspnet-subscriptions/Configuration/SubscriptionServerOptions.cs
+++ b/src/graphql-aspnet-subscriptions/Configuration/SubscriptionServerOptions.cs
@@ -99,6 +99,6 @@ namespace GraphQL.AspNet.Configuration
         /// </summary>
         /// <value><c>true</c> if an authenticated request is required to complete
         /// a subscription client connection; otherwise, <c>false</c>.</value>
-        public bool RequiredAuthenticatedConnection { get; set; } = false;
+        public bool AuthenticatedRequestsOnly { get; set; } = false;
     }
 }


### PR DESCRIPTION
* Changed the value `SubscriptionServerOptions.RequiredAuthenticatedConnection` to `AuthenticatedRequestsOnly` to match the language used on `SchemaQueryHandlerConfiguration` which offers a similar configuration option for the default stateless http query processor.