### PR TITLE
Updated Rule Specification URLs

### DIFF
--- a/src/graphql-aspnet/Configuration/SchemaOptions.cs
+++ b/src/graphql-aspnet/Configuration/SchemaOptions.cs
@@ -21,7 +21,7 @@ namespace GraphQL.AspNet.Configuration
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
-    /// Startup configuration settings to setup a schema.
+    /// A complete set of configuration options to setup a schema.
     /// </summary>
     public class SchemaOptions
     {

--- a/src/graphql-aspnet/Constants.cs
+++ b/src/graphql-aspnet/Constants.cs
@@ -462,5 +462,12 @@ namespace GraphQL.AspNet
             /// </summary>
             public const string FIELD_AUTHORIZATION_PIPELINE = "Field Authorization Pipeline";
         }
+
+        /// <summary>
+        /// Gets a URL pointing to the page of the graphql specification this library
+        /// targets. This value is used as a base url for most validation rules to generate
+        /// a link pointing to a violated rule.
+        /// </summary>
+        public const string SPECIFICATION_URL = "http://spec.graphql.org/June2018/";
     }
 }

--- a/src/graphql-aspnet/Execution/GraphSchemaInitializer.cs
+++ b/src/graphql-aspnet/Execution/GraphSchemaInitializer.cs
@@ -35,11 +35,10 @@ namespace GraphQL.AspNet.Execution
 
         /// <summary>
         /// Initializes the schema:
-        /// * Add any controllers to the schema instance that were configured during startup.
-        /// * add all methods, virtual graph types, return types parameters and property configuration.
-        /// * Add any additional types added at startup.
-        /// * Register introspection meta-fields.
-        /// * Compile and instantiate the resolution pipeline.
+        /// <para>* Add any controllers to the schema instance that were configured during startup.</para>
+        /// <para>* Add all methods, virtual graph types, return types parameters and property configurations.</para>
+        /// <para>* Add any additional types added at startup.</para>
+        /// <para>* Register introspection meta-fields.</para>
         /// </summary>
         /// <param name="schema">The schema to initialize.</param>
         public virtual void Initialize(ISchema schema)

--- a/src/graphql-aspnet/Execution/OperationExecutionResult.cs
+++ b/src/graphql-aspnet/Execution/OperationExecutionResult.cs
@@ -9,12 +9,14 @@
 
 namespace GraphQL.AspNet.Execution
 {
+    using System.Diagnostics;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Response;
 
     /// <summary>
     /// An instance of a result to executing an graphql operation.
     /// </summary>
+    [DebuggerDisplay("Messages = {Messages.Count}")]
     public class OperationExecutionResult : IOperationExecutionResult
     {
         /// <summary>

--- a/src/graphql-aspnet/ValidationRules/ReferenceRule.cs
+++ b/src/graphql-aspnet/ValidationRules/ReferenceRule.cs
@@ -1,0 +1,44 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.ValidationRules
+{
+    using System.Text;
+
+    /// <summary>
+    /// A helper method to build a url that points to a rule in
+    /// a specific graphql specification document.
+    /// </summary>
+    internal static class ReferenceRule
+    {
+        /// <summary>
+        /// Creates a url to reference rule to the graphql specification document
+        /// this library supports at the indicated place on the web page.
+        /// </summary>
+        /// <param name="anchorTag">The anchor tag to append to the
+        /// specification document link. If null the root of the document
+        /// page is returned.</param>
+        /// <returns>System.String.</returns>
+        public static string Create(string anchorTag)
+        {
+            var builder = new StringBuilder();
+            builder.Append(Constants.SPECIFICATION_URL);
+
+            if (!string.IsNullOrWhiteSpace(anchorTag))
+            {
+                if (!anchorTag.StartsWith("#"))
+                    builder.Append("#");
+
+                builder.Append(anchorTag);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/Common/DocumentConstructionRuleStep.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/Common/DocumentConstructionRuleStep.cs
@@ -47,9 +47,17 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Common
         public abstract string RuleNumber { get; }
 
         /// <summary>
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If <see cref="ReferenceUrl"/> is overriden
+        /// this value is ignored.
+        /// </summary>
+        /// <value>The rule anchor tag.</value>
+        protected abstract string RuleAnchorTag { get; }
+
+        /// <summary>
         /// Gets a url pointing to the rule definition in the graphql specification, if any.
         /// </summary>
         /// <value>The rule URL.</value>
-        public abstract string ReferenceUrl { get; }
+        public virtual string ReferenceUrl => ReferenceRule.Create(this.RuleAnchorTag);
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_1_DirectiveMustBeDefinedInTheSchema.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_1_DirectiveMustBeDefinedInTheSchema.cs
@@ -46,9 +46,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Directive
         public override string RuleNumber => "5.7.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Directives-Are-Defined";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Directives-Are-Defined";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_2_DirectiveMustBeUsedInValidLocation.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_2_DirectiveMustBeUsedInValidLocation.cs
@@ -58,9 +58,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Directive
         public override string RuleNumber => "5.7.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Directives-Are-In-Valid-Locations";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Directives-Are-In-Valid-Locations";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_3_DirectiveIsDefinedNoMoreThanOncePerLocation.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/DirectiveNodeSteps/Rule_5_7_3_DirectiveIsDefinedNoMoreThanOncePerLocation.cs
@@ -51,9 +51,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Directive
         public override string RuleNumber => "5.7.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Directives-Are-Unique-Per-Location";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Directives-Are-Unique-Per-Location";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_1_FieldMustExistOnTargetGraphType.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_1_FieldMustExistOnTargetGraphType.cs
@@ -82,9 +82,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FieldNode
         public override string RuleNumber => "5.3.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_2_FieldsOfIdenticalOutputMustHaveIdenticalSigs.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_2_FieldsOfIdenticalOutputMustHaveIdenticalSigs.cs
@@ -210,9 +210,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FieldNode
         public override string RuleNumber => "5.3.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Field-Selection-Merging";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Field-Selection-Merging";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_3_LeafReturnMustNotHaveChildFields.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/Rule_5_3_3_LeafReturnMustNotHaveChildFields.cs
@@ -65,9 +65,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FieldNode
         public override string RuleNumber => "5.3.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Leaf-Field-Selections";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Leaf-Field-Selections";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/TypeNameMetaField_SpecialCase.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FieldNodeSteps/TypeNameMetaField_SpecialCase.cs
@@ -84,9 +84,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FieldNode
         public override string RuleNumber => "5.3.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Field-Selections-on-Objects-Interfaces-and-Unions-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_1_SpreadOfNamedFragmentMustExist.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_1_SpreadOfNamedFragmentMustExist.cs
@@ -46,9 +46,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.1";
 
         /// <summary>
-        /// Gets the reference URL.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The reference URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-spread-target-defined";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragment-spread-target-defined";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_2_SpreadingANamedFragmentMustNotFormCycles.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_2_SpreadingANamedFragmentMustNotFormCycles.cs
@@ -140,9 +140,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.2";
 
         /// <summary>
-        /// Gets the reference URL.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The reference URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-spreads-must-not-form-cycles";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragment-spreads-must-not-form-cycles";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_1_ObjectFragmentSpreadInObjectCanSpreadInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_1_ObjectFragmentSpreadInObjectCanSpreadInContext.cs
@@ -57,9 +57,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.3.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Object-Spreads-In-Object-Scope";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Object-Spreads-In-Object-Scope";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_2_AbstractFragmentSpreadInObjectCanSpreadInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_2_AbstractFragmentSpreadInObjectCanSpreadInContext.cs
@@ -59,9 +59,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.3.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Abstract-Spreads-in-Object-Scope";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Abstract-Spreads-in-Object-Scope";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_3_ObjectFragmentSpreadInAbstractCanSpreadInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_3_ObjectFragmentSpreadInAbstractCanSpreadInContext.cs
@@ -59,9 +59,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.3.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Object-Spreads-In-Abstract-Scope";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Object-Spreads-In-Abstract-Scope";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_4_AbstractFragmentSpreadInAbstractCanSpreadInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/FragmentSpreadNodeSteps/Rule_5_5_2_3_4_AbstractFragmentSpreadInAbstractCanSpreadInContext.cs
@@ -63,9 +63,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.FragmentS
         public override string RuleNumber => "5.5.2.3.4";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Abstract-Spreads-in-Abstract-Scope";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Abstract-Spreads-in-Abstract-Scope";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemCollectionNodeSteps/Rule_5_4_InputItemsOnlyOnFieldsOrDirectives.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemCollectionNodeSteps/Rule_5_4_InputItemsOnlyOnFieldsOrDirectives.cs
@@ -46,9 +46,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.4";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Validation.Arguments";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Validation.Arguments";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_1_A_ArgumentMustBeDefinedOnTheField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_1_A_ArgumentMustBeDefinedOnTheField.cs
@@ -61,9 +61,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.4.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Argument-Names";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Argument-Names";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_1_B_ArgumentMustBeDefinedOnTheDirective.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_1_B_ArgumentMustBeDefinedOnTheDirective.cs
@@ -61,9 +61,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.4.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Argument-Names";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Argument-Names";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_2_A_ArgumentMustBeUniqueOnTheField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_2_A_ArgumentMustBeUniqueOnTheField.cs
@@ -61,9 +61,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.4.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Argument-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Argument-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_2_B_ArgumentMustBeUniqueOnTheDirective.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_4_2_B_ArgumentMustBeUniqueOnTheDirective.cs
@@ -61,9 +61,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.4.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Argument-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Argument-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_6_2_InputObjectFieldsMustExistOnTargetGraphType.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_6_2_InputObjectFieldsMustExistOnTargetGraphType.cs
@@ -66,9 +66,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.6.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Field-Names";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Input-Object-Field-Names";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_6_3_InputObjectFieldNamesMustBeUnique.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputItemNodeSteps/Rule_5_6_3_InputObjectFieldNamesMustBeUnique.cs
@@ -66,9 +66,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputItem
         public override string RuleNumber => "5.6.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Field-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Input-Object-Field-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputValueNodeSteps/InputValue_AssignVariableReference.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputValueNodeSteps/InputValue_AssignVariableReference.cs
@@ -57,9 +57,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputValu
         public override string RuleNumber => "5.8.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-All-Variable-Uses-Defined";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-All-Variable-Uses-Defined";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputValueNodeSteps/Rule_5_8_3_AllUsedVariablesMustBeDeclaredOnTheOperation.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/InputValueNodeSteps/Rule_5_8_3_AllUsedVariablesMustBeDeclaredOnTheOperation.cs
@@ -51,9 +51,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.InputValu
         public override string RuleNumber => "5.8.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-All-Variable-Uses-Defined";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-All-Variable-Uses-Defined";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/NamedFragmentNodeSteps/Rule_5_5_1_1_FragmentNamesMustBeUnique.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/NamedFragmentNodeSteps/Rule_5_5_1_1_FragmentNamesMustBeUnique.cs
@@ -48,9 +48,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.NamedFrag
         public override string RuleNumber => "5.5.1.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-Name-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragment-Name-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_1_1_OperationNamesMustBeUnique.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_1_1_OperationNamesMustBeUnique.cs
@@ -59,9 +59,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Operation
         public override string RuleNumber => "5.2.1.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Operation-Name-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Operation-Name-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_3_1_SubscriptionsRequire1RootField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_3_1_SubscriptionsRequire1RootField.cs
@@ -59,9 +59,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Operation
         public override string RuleNumber => "5.2.3.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Single-root-field";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_OperationTypeMustBeDefinedOnTheSchema.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/OperationNodeSteps/Rule_5_2_OperationTypeMustBeDefinedOnTheSchema.cs
@@ -69,9 +69,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.Operation
         public override string RuleNumber => "5.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Validation.Operations";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Validation.Operations";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/QueryFragmentSteps/Rule_5_5_1_2_FragmentGraphTypeMustExistInTheSchema.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/QueryFragmentSteps/Rule_5_5_1_2_FragmentGraphTypeMustExistInTheSchema.cs
@@ -55,9 +55,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.QueryFrag
         public override string RuleNumber => "5.5.1.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-Spread-Type-Existence";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragment-Spread-Type-Existence";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/QueryFragmentSteps/Rule_5_5_1_3_FragmentTargetTypeMustBeOfAllowedKind.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/QueryFragmentSteps/Rule_5_5_1_3_FragmentTargetTypeMustBeOfAllowedKind.cs
@@ -68,9 +68,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.QueryFrag
         public override string RuleNumber => "5.5.1.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragment-Spread-Type-Existence";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragments-On-Composite-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/TopLevelNodeSteps/Rule_5_1_1_ExecutableDefinitions.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/TopLevelNodeSteps/Rule_5_1_1_ExecutableDefinitions.cs
@@ -77,9 +77,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.TopLevelN
         public override string RuleNumber => "5.1.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Executable-Definitions";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Executable-Definitions";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableCollectionNodeSteps/Rule_5_8_OnlyOperationsCanDeclareVariables.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableCollectionNodeSteps/Rule_5_8_OnlyOperationsCanDeclareVariables.cs
@@ -46,9 +46,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.VariableC
         public override string RuleNumber => "5.8";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Validation.Variables";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Validation.Variables";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_1_VariableNamesMustBeUnique.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_1_VariableNamesMustBeUnique.cs
@@ -52,9 +52,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.VariableN
         public override string RuleNumber => "5.8.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Variable-Uniqueness";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Variable-Uniqueness";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_A_VariablesMustDeclareAType.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_A_VariablesMustDeclareAType.cs
@@ -47,9 +47,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.VariableN
         public override string RuleNumber => "5.8.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Variables-Are-Input-Types";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Variables-Are-Input-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_B_VariablesMustDeclareAValidGraphType.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_B_VariablesMustDeclareAValidGraphType.cs
@@ -50,9 +50,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.VariableN
         public override string RuleNumber => "5.8.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Variables-Are-Input-Types";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Variables-Are-Input-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_C_VariableGraphTypeMustBeOfAllowedTypeKinds.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentConstruction/VariableNodeSteps/Rule_5_8_2_C_VariableGraphTypeMustBeOfAllowedTypeKinds.cs
@@ -57,9 +57,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentConstruction.VariableN
         public override string RuleNumber => "5.8.2";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Variables-Are-Input-Types";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Variables-Are-Input-Types";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/Common/DocumentPartValidationRuleStep.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/Common/DocumentPartValidationRuleStep.cs
@@ -49,9 +49,17 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.Common
         public abstract string RuleNumber { get; }
 
         /// <summary>
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If <see cref="ReferenceUrl"/> is overriden
+        /// this value is ignored.
+        /// </summary>
+        /// <value>The rule anchor tag.</value>
+        protected abstract string RuleAnchorTag { get; }
+
+        /// <summary>
         /// Gets a url pointing to the rule definition in the graphql specification, if any.
         /// </summary>
         /// <value>The rule URL.</value>
-        public abstract string ReferenceUrl { get; }
+        public virtual string ReferenceUrl => ReferenceRule.Create(this.RuleAnchorTag);
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
@@ -58,9 +58,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.FieldSelect
         public override string RuleNumber => "5.4.2.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Required-Arguments";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Required-Arguments";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
@@ -54,9 +54,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryDirect
         public override string RuleNumber => "5.4.2.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Required-Arguments";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Required-Arguments";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_4_AllDeclaredFragmentsMustBeUsed.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_4_AllDeclaredFragmentsMustBeUsed.cs
@@ -48,9 +48,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryFragme
         public override string RuleNumber => "5.5.1.4";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Fragments-Must-Be-Used";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Fragments-Must-Be-Used";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputArgumentSteps/Rule_5_8_5_VariableValueMustBeUsableInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputArgumentSteps/Rule_5_8_5_VariableValueMustBeUsableInContext.cs
@@ -67,9 +67,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputA
         public override string RuleNumber => "5.8.5";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-All-Variable-Usages-are-Allowed";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-All-Variable-Usages-are-Allowed";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_1_ValueMustBeCoerceable.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_1_ValueMustBeCoerceable.cs
@@ -211,9 +211,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
         public override string RuleNumber => "5.6.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Values-of-Correct-Type";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Values-of-Correct-Type";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_4_InputObjectRequiredFieldsMustBeProvided.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_4_InputObjectRequiredFieldsMustBeProvided.cs
@@ -79,9 +79,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
         public override string RuleNumber => "5.6.4";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Input-Object-Required-Fields";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Input-Object-Required-Fields";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryOperationSteps/Rule_5_2_2_1_LoneAnonymousOperation.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryOperationSteps/Rule_5_2_2_1_LoneAnonymousOperation.cs
@@ -64,9 +64,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryOperat
         public override string RuleNumber => "5.2.2.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Lone-Anonymous-Operation";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Lone-Anonymous-Operation";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryOperationSteps/Rule_5_2_3_1_1_SubscriptionsRequire1EncounteredSubscriptionField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryOperationSteps/Rule_5_2_3_1_1_SubscriptionsRequire1EncounteredSubscriptionField.cs
@@ -132,9 +132,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryOperat
         public override string RuleNumber => "5.2.3.1.1";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Single-root-field";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Single-root-field";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryVariableSteps/Rule_5_8_4_AllVariablesMustBeUsedInTheOperation.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryVariableSteps/Rule_5_8_4_AllVariablesMustBeUsedInTheOperation.cs
@@ -47,9 +47,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryVariab
         public override string RuleNumber => "5.8.4";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-All-Variables-Used";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-All-Variables-Used";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/Common/FieldResolutionRuleStep.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/Common/FieldResolutionRuleStep.cs
@@ -10,6 +10,7 @@
 namespace GraphQL.AspNet.ValidationRules.RuleSets.FieldResolution.Common
 {
     using System;
+    using System.Text;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Middleware.FieldExecution;
     using GraphQL.AspNet.ValidationRules.Interfaces;
@@ -53,9 +54,17 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.FieldResolution.Common
         public abstract string RuleNumber { get; }
 
         /// <summary>
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If <see cref="ReferenceUrl"/> is overriden
+        /// this value is ignored.
+        /// </summary>
+        /// <value>The rule anchor tag.</value>
+        protected abstract string RuleAnchorTag { get; }
+
+        /// <summary>
         /// Gets a url pointing to the rule definition in the graphql specification, if any.
         /// </summary>
         /// <value>The rule URL.</value>
-        public abstract string ReferenceUrl { get; }
+        public virtual string ReferenceUrl => ReferenceRule.Create(this.RuleAnchorTag);
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/FieldCompletion/Rule_6_4_3_SchemaValueCompletion.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/FieldCompletion/Rule_6_4_3_SchemaValueCompletion.cs
@@ -118,9 +118,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.FieldResolution.FieldCompletio
         public override string RuleNumber => "6.4.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Value-Completion";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Value-Completion";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/FieldCompletion/Rule_6_4_3_ServerValueCompletion.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/FieldResolution/FieldCompletion/Rule_6_4_3_ServerValueCompletion.cs
@@ -88,9 +88,11 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.FieldResolution.FieldCompletio
         public override string RuleNumber => "6.4.3";
 
         /// <summary>
-        /// Gets a url pointing to the rule definition in the graphql specification, if any.
+        /// Gets an anchor tag, pointing to a specific location on the webpage identified
+        /// as the specification supported by this library. If ReferenceUrl is overriden
+        /// this value is ignored.
         /// </summary>
-        /// <value>The rule URL.</value>
-        public override string ReferenceUrl => "https://graphql.github.io/graphql-spec/June2018/#sec-Value-Completion";
+        /// <value>The rule anchor tag.</value>
+        protected override string RuleAnchorTag => "#sec-Value-Completion";
     }
 }

--- a/src/tests/graphql-aspnet-tests/ValidationRuless/EnsureValidationRuleUrls.cs
+++ b/src/tests/graphql-aspnet-tests/ValidationRuless/EnsureValidationRuleUrls.cs
@@ -1,0 +1,116 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.ValidationRuless
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Generics;
+    using GraphQL.AspNet.ValidationRules.Interfaces;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class EnsureValidationRuleUrls
+    {
+        [Test]
+        public void EnsureAllUrlsUniquePerRule()
+        {
+            // for all links to specification rules ensure that
+            // each rule number has a valid link and that it is
+            // unique
+            var ruleTypes = typeof(GraphQLProviders)
+                .Assembly
+                .GetTypes()
+                .Where(Validation.IsCastable<IValidationRule>)
+                .Where(x => x != typeof(IValidationRule) &&
+                           !x.IsAbstract && x.IsClass);
+
+            var builder = new StringBuilder();
+
+            var urlsByRule = new Dictionary<string, HashSet<string>>();
+            var rulesByUrl = new Dictionary<string, HashSet<string>>();
+            foreach (var type in ruleTypes)
+            {
+                var obj = InstanceFactory.CreateInstance(type) as IValidationRule;
+
+                var ruleNumber = obj.RuleNumber;
+                var url = obj.ReferenceUrl;
+
+                if (!urlsByRule.ContainsKey(ruleNumber))
+                    urlsByRule.Add(ruleNumber, new HashSet<string>());
+
+                var uri = new Uri(url);
+                Assert.IsTrue(uri.IsWellFormedOriginalString());
+
+                if (!url.Contains("#"))
+                {
+                    builder.AppendLine($"Url for Rule {ruleNumber} ({type.Name}) does not contain an section anchor.");
+                    continue;
+                }
+
+                urlsByRule[ruleNumber].Add(url);
+
+                if (!rulesByUrl.ContainsKey(url))
+                    rulesByUrl.Add(url, new HashSet<string>());
+
+                rulesByUrl[url].Add(ruleNumber);
+            }
+
+            var multipleUrls = urlsByRule.Where(x => x.Value.Count > 1);
+            if (multipleUrls.Any())
+            {
+                var ruleList = string.Join(", ", multipleUrls.Select(x => x.Key));
+                builder.AppendLine($"Rules {ruleList} have multiple urls defined.");
+            }
+
+            var multipleRules = rulesByUrl.Where(x => x.Value.Count > 1);
+            if (multipleRules.Any())
+            {
+                foreach (var kvp in multipleRules)
+                {
+                    // nested rules are allowed to double up
+                    // for instance 5.2.3.1.1 can have the same
+                    // url as 5.2.3.1 because not all sub rules are
+                    // defined as their own sections
+
+                    var list = kvp.Value
+                        .OrderBy(x => x)
+                        .ToList();
+
+                    var unnestedRules = new HashSet<string>();
+                    for (var i = 1; i < list.Count; i++)
+                    {
+                        var prev = list[i - 1];
+                        var cur = list[i];
+
+                        if (!cur.StartsWith(prev))
+                        {
+                            unnestedRules.Add(prev);
+                            unnestedRules.Add(cur);
+                        }
+                    }
+
+                    if (unnestedRules.Count > 0)
+                    {
+                        var ruleList = string.Join(", ", unnestedRules);
+                        var msg = $"Rules {ruleList} must have unique urls. (url: {kvp.Key})";
+                        builder.AppendLine(msg);
+                    }
+                }
+
+                var str = builder.ToString();
+                if (!string.IsNullOrEmpty(str))
+                    Assert.Fail(str);
+            }
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/ValidationRuless/EnsureValidationRuleUrls.cs
+++ b/src/tests/graphql-aspnet-tests/ValidationRuless/EnsureValidationRuleUrls.cs
@@ -81,7 +81,6 @@ namespace GraphQL.AspNet.Tests.ValidationRuless
                     // for instance 5.2.3.1.1 can have the same
                     // url as 5.2.3.1 because not all sub rules are
                     // defined as their own sections
-
                     var list = kvp.Value
                         .OrderBy(x => x)
                         .ToList();

--- a/src/utilities/graphql-aspnet-validationrule-extractor/.gitignore
+++ b/src/utilities/graphql-aspnet-validationrule-extractor/.gitignore
@@ -1,0 +1,1 @@
+graphql-aspnet-rulesList.csv

--- a/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor.sln
+++ b/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "graphql-aspnet-validationrule-extractor", "graphql-aspnet-validationrule-extractor\graphql-aspnet-validationrule-extractor.csproj", "{F70683CE-4E69-4439-B42A-4256166AE103}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "graphql-aspnet", "..\..\graphql-aspnet\graphql-aspnet.csproj", "{C2C3E65E-140C-46A7-98D9-5D6E14B03A68}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "graphql-aspnet-subscriptions", "..\..\graphql-aspnet-subscriptions\graphql-aspnet-subscriptions.csproj", "{015C1622-F249-4301-994E-F86FDECB978C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F70683CE-4E69-4439-B42A-4256166AE103}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F70683CE-4E69-4439-B42A-4256166AE103}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F70683CE-4E69-4439-B42A-4256166AE103}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F70683CE-4E69-4439-B42A-4256166AE103}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2C3E65E-140C-46A7-98D9-5D6E14B03A68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2C3E65E-140C-46A7-98D9-5D6E14B03A68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2C3E65E-140C-46A7-98D9-5D6E14B03A68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2C3E65E-140C-46A7-98D9-5D6E14B03A68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{015C1622-F249-4301-994E-F86FDECB978C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{015C1622-F249-4301-994E-F86FDECB978C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{015C1622-F249-4301-994E-F86FDECB978C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{015C1622-F249-4301-994E-F86FDECB978C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {386C89AC-0D57-4C40-A5C2-703076A147DC}
+	EndGlobalSection
+EndGlobal

--- a/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor/Program.cs
+++ b/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor/Program.cs
@@ -1,0 +1,83 @@
+﻿namespace GraphQL.AspNet.Utility.ValidationRuleExtractor
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Generics;
+    using GraphQL.AspNet.ValidationRules.Interfaces;
+    using GraphQL.AspNet.Common.Extensions;
+    using System.Collections.Generic;
+
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            // this utility scans the graphql aspnet libraries
+            // extracting any IValidationRule classes
+            // serialzing out the rule number, the URL it points to
+            // and hte class implementing it to a CSV file
+            // for easy manipulation
+            //
+            // especially useful when the spec changes
+            // and urls need to be validated for accuracy
+
+            var ruleTypes = typeof(GraphQLProviders)
+                .Assembly
+                .GetTypes()
+                .Where(Validation.IsCastable<IValidationRule>)
+                .Where(x => x != typeof(IValidationRule) &&
+                           !x.IsAbstract && x.IsClass);
+
+            // hack our way up to the solution directory
+            var fi = new FileInfo(typeof(Program).Assembly.Location);
+            var dir = fi.Directory;
+            while(dir != null)
+            {
+                if (dir.GetFiles("*.sln").Any())
+                    break;
+
+                dir = dir.Parent;
+            }
+
+            Validation.ThrowIfNull(dir, "solution directory");
+
+            var lines = new List<string>();
+            var rules = new HashSet<string>();
+            foreach (var type in ruleTypes)
+            {
+                var obj = InstanceFactory.CreateInstance(type) as IValidationRule;
+
+                var ruleNumber = obj.RuleNumber;
+                var url = obj.ReferenceUrl;
+
+                var i = 1;
+                var rulePrint = ruleNumber;
+                while (rules.Contains(rulePrint))
+                    rulePrint = $"{ruleNumber}-{i++}";
+                rules.Add(rulePrint);
+
+                Console.WriteLine("Exactracting Rule: {0}", rulePrint);
+                lines.Add(string.Format("\"{0}\",{1},{2}",
+                    ruleNumber,
+                    type.FriendlyName(),
+                    url));
+            }
+
+            lines = lines.OrderBy(x => x).ToList();
+            var outputFile = Path.Combine(dir.FullName, "graphql-aspnet-rulesList.csv");
+            using var writer = new StreamWriter(outputFile, false);
+
+            foreach(var line in lines)
+                writer.WriteLine(line);
+
+            writer.Close();
+
+            Console.WriteLine("Rule List Generated at: {1}{0}",
+                outputFile,
+                Environment.NewLine);
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+    }
+}

--- a/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor.csproj
+++ b/src/utilities/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor/graphql-aspnet-validationrule-extractor.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>GraphQL.AspNet.Utility.ValidationRuleExtractor</RootNamespace>
+    <AssemblyName>GraphQL.AspNet.Utility.ValidationRuleExtractor</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\graphql-aspnet-subscriptions\graphql-aspnet-subscriptions.csproj" />
+    <ProjectReference Include="..\..\..\graphql-aspnet\graphql-aspnet.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Refactored the way specification rules are supplied via validations error to more easily handle specification updates or changes in the future. 

**This PR contains no new functionality**

* Updated the urls pointed to by each validation rule to match the new spec URL base (https://spec.graphql.org)
* Centralized the base URL to a constants (instead of being repeated per rule) and added a new protected tag property for the anchor tag (location on the spec page) to which each rule is referencing.
* Added a side utility (src/utilities) that will scan the graphql-aspnet assembly and extract the rule number, class implementing it, and the spec URL int a CSV file for easy reference when needed.
* Added a new unit test to ensure that each rule number has a unique URL