### PR TITLE
Fixed Validation issue with non scalar child fields of proxied parents 

### DIFF
--- a/src/graphql-aspnet/Execution/FieldResolution/GraphFieldDataSource.cs
+++ b/src/graphql-aspnet/Execution/FieldResolution/GraphFieldDataSource.cs
@@ -10,12 +10,14 @@
 namespace GraphQL.AspNet.Execution.FieldResolution
 {
     using System.Collections.Generic;
+    using System.Diagnostics;
     using GraphQL.AspNet.Common.Source;
 
     /// <summary>
     /// An item, that may contain a collection of data items or just one, that acts as an input source to a
     /// field execution pipeline.
     /// </summary>
+    [DebuggerDisplay("{Path} (Count: {Items.Count})")]
     public class GraphFieldDataSource
     {
         /// <summary>

--- a/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
@@ -16,9 +16,11 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
     using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Common.Generics;
     using GraphQL.AspNet.Common.Source;
     using GraphQL.AspNet.Execution;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Execution.FieldResolution;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Middleware;
@@ -171,7 +173,7 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
                     var task = _fieldExecutionPipeline.InvokeAsync(childContext, cancelToken)
                         .ContinueWith(invokeTask =>
                         {
-                            context.Messages.AddRange(childContext.Messages);
+                            this.CaptureChildFieldExecutionResults(context, childContext, invokeTask);
                         });
 
                     pipelines.Add(task);
@@ -190,6 +192,40 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
                 {
                     await task.ConfigureAwait(false);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Inspects both the childcontext and the invoked task to determine
+        /// if any messages were found or any unhandled exceptions were thrown then
+        /// captures the results into the parent context for upstream processing or
+        /// reporting.
+        /// </summary>
+        /// <param name="parentContext">The parent context that invoked the child.</param>
+        /// <param name="childContext">The child context that was invoked.</param>
+        /// <param name="childExecutionTask">The actual task representing the child
+        /// pipeline.</param>
+        private void CaptureChildFieldExecutionResults(
+            GraphFieldExecutionContext parentContext,
+            GraphFieldExecutionContext childContext,
+            Task childExecutionTask)
+        {
+            // capture any messages that the child context may have internally reported
+            parentContext.Messages.AddRange(childContext.Messages);
+
+            // inspect the task for faulting and capture any exceptions as critical errors
+            if (childExecutionTask.IsFaulted)
+            {
+                var exception = childExecutionTask.UnwrapException();
+                exception = exception ?? new Exception(
+                    "Unknown Error. The child field execution pipeline indicated a fault but did not " +
+                    "provide a reason. This exception represents an unknown cause for the child pipeline failure.");
+
+                parentContext.Messages.Critical(
+                    $"Processing field '{childContext.Field.Name}' of '{parentContext.Field.Route}' resulted in a critical failure. See exception for details.",
+                    Constants.ErrorCodes.EXECUTION_ERROR,
+                    childContext.InvocationContext.Origin,
+                    exception);
             }
         }
 

--- a/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
@@ -219,7 +219,7 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
                 var exception = childExecutionTask.UnwrapException();
                 exception = exception ?? new Exception(
                     "Unknown Error. The child field execution pipeline indicated a fault but did not " +
-                    "provide a reason. This exception represents an unknown cause for the child pipeline failure.");
+                    "provide a reason for the failure.");
 
                 parentContext.Messages.Critical(
                     $"Processing field '{childContext.Field.Name}' of '{parentContext.Field.Route}' resulted in a critical failure. See exception for details.",

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/Blog.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/Blog.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+
+    public class Blog
+    {
+        public int BlogId { get; set; }
+
+        public string Url { get; set; }
+
+        public virtual IList<BlogPost> Posts { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections;
     using System.Collections.Generic;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
@@ -35,6 +34,19 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
                 Content = "Content 1",
                 Title = "Title 1",
                 Blog = blog,
+                Comments = new List<BlogPostComment>()
+                {
+                    new BlogPostCommentProxy()
+                    {
+                        CommentId = 30,
+                        Comment = "Comment 30",
+                    },
+                    new BlogPostCommentProxy()
+                    {
+                        CommentId = 31,
+                        Comment = "Comment 31",
+                    },
+                },
             });
 
             blog.Posts.Add(new BlogPostProxy()
@@ -44,7 +56,21 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
                 Content = "Content 2",
                 Title = "Title 2",
                 Blog = blog,
+                Comments = new List<BlogPostComment>()
+                {
+                    new BlogPostCommentProxy()
+                    {
+                        CommentId = 32,
+                        Comment = "Comment 32",
+                    },
+                    new BlogPostCommentProxy()
+                    {
+                        CommentId = 33,
+                        Comment = "Comment 33",
+                    },
+                },
             });
+
             list.Add(blog);
 
             return this.Ok(list);

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
@@ -17,7 +17,6 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 
     public class BlogController : GraphController
     {
-
         [QueryRoot("blogs", typeof(IEnumerable<Blog>))]
         public IGraphActionResult RetrieveBlogs()
         {

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogController.cs
@@ -1,0 +1,54 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Interfaces.Controllers;
+
+    public class BlogController : GraphController
+    {
+
+        [QueryRoot("blogs", typeof(IEnumerable<Blog>))]
+        public IGraphActionResult RetrieveBlogs()
+        {
+            var list = new List<Blog>();
+
+            var blog = new BlogProxy()
+            {
+                BlogId = 1,
+                Url = "http://blog.com",
+                Posts = new List<BlogPost>(),
+            };
+            blog.Posts.Add(new BlogPostProxy()
+            {
+                BlogId = 1,
+                PostId = 1,
+                Content = "Content 1",
+                Title = "Title 1",
+                Blog = blog,
+            });
+
+            blog.Posts.Add(new BlogPostProxy()
+            {
+                BlogId = 1,
+                PostId = 2,
+                Content = "Content 2",
+                Title = "Title 2",
+                Blog = blog,
+            });
+            list.Add(blog);
+
+            return this.Ok(list);
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPost.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPost.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    public class BlogPost
+    {
+        public int PostId { get; set; }
+
+        public string Title { get; set; }
+
+        public string Content { get; set; }
+
+        public int BlogId { get; set; }
+
+        public virtual Blog Blog { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostComment.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostComment.cs
@@ -9,20 +9,10 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections.Generic;
-
-    public class BlogPost
+    public class BlogPostComment
     {
-        public int PostId { get; set; }
+        public int CommentId { get; set; }
 
-        public string Title { get; set; }
-
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-
-        public virtual Blog Blog { get; set; }
-
-        public virtual IList<BlogPostComment> Comments { get; set; }
+        public string Comment { get; set; }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostCommentProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostCommentProxy.cs
@@ -9,20 +9,7 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections.Generic;
-
-    public class BlogPost
+    public class BlogPostCommentProxy : BlogPostComment
     {
-        public int PostId { get; set; }
-
-        public string Title { get; set; }
-
-        public string Content { get; set; }
-
-        public int BlogId { get; set; }
-
-        public virtual Blog Blog { get; set; }
-
-        public virtual IList<BlogPostComment> Comments { get; set; }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostProxy.cs
@@ -1,11 +1,14 @@
-﻿namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
 
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
     public class BlogPostProxy : BlogPost
     {
     }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogPostProxy.cs
@@ -1,0 +1,12 @@
+﻿namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class BlogPostProxy : BlogPost
+    {
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+
+    public class BlogProxy : Blog
+    {
+
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
@@ -13,6 +13,5 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 
     public class BlogProxy : Blog
     {
-
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -13,6 +13,7 @@ namespace GraphQL.AspNet.Tests.Execution
     using System.Threading.Tasks;
     using GraphQL.AspNet.Directives.Global;
     using GraphQL.AspNet.Execution;
+    using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData;
     using GraphQL.AspNet.Tests.Framework;

--- a/src/tests/graphql-aspnet-tests/Execution/RuntimeTypeInferenceTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/RuntimeTypeInferenceTests.cs
@@ -185,9 +185,11 @@ namespace GraphQL.AspNet.Tests.Execution
                     })
                     .Build();
 
-            // blogs returns a BlogProxyObject,  the [type]/Blog/posts field should
+            // blogs returns a BlogProxyObject
+            // the [type]/Blog/posts field should
             // validate the Type BlogProxy as being a valid Blog that it can
             // use as a source
+            // same with BlogPost/BlogPostProxy and BlogPostComment/BlogPostCommentProxy
             var builder = server.CreateQueryContextBuilder()
             .AddQueryText(
             @"query  {
@@ -196,7 +198,11 @@ namespace GraphQL.AspNet.Tests.Execution
                             url,
                             posts {
                                 postId,
-                                title
+                                title,
+                                comments {
+                                    commentId,
+                                    comment
+                                }
                             }
                     }}");
 
@@ -210,17 +216,37 @@ namespace GraphQL.AspNet.Tests.Execution
                     ""posts"": [
                       {
                         ""postId"": 1,
-                        ""title"": ""Title 1""
+                        ""title"": ""Title 1"",
+                        ""comments"": [
+                          {
+                            ""commentId"": 30,
+                            ""comment"": ""Comment 30""
+                          },
+                          {
+                            ""commentId"": 31,
+                            ""comment"": ""Comment 31""
+                          }
+                        ]
                       },
                       {
                         ""postId"": 2,
-                        ""title"": ""Title 2""
+                        ""title"": ""Title 2"",
+                        ""comments"": [
+                          {
+                            ""commentId"": 32,
+                            ""comment"": ""Comment 32""
+                          },
+                          {
+                            ""commentId"": 33,
+                            ""comment"": ""Comment 33""
+                          }
+                        ]
                       }
                     ]
                   }
                 ]
               }
-            }";
+                }";
 
             var outputJson = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedResult, outputJson);

--- a/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTestData/ForceExceptionForProperty1Middlware.cs
+++ b/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTestData/ForceExceptionForProperty1Middlware.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Middleware.QueryPipelineIntegrationTestData
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Interfaces.Middleware;
+    using GraphQL.AspNet.Middleware;
+    using GraphQL.AspNet.Middleware.FieldExecution;
+
+    public class ForceExceptionForProperty1Middlware : IGraphFieldExecutionMiddleware
+    {
+        public Task InvokeAsync(GraphFieldExecutionContext context, GraphMiddlewareInvocationDelegate<GraphFieldExecutionContext> next, CancellationToken cancelToken)
+        {
+            if (context.Field.Name.Contains("property1", System.StringComparison.OrdinalIgnoreCase))
+                throw new GraphExecutionException("Forced Exception for testing");
+
+            return next(context, cancelToken);
+        }
+    }
+}


### PR DESCRIPTION
* Fixed an issue where attempting to resolve a non-scalar child of  a proxied source object resulted in an erroneous source validation failure and dropped the results.  The wrong expected input type was being supplied to the type analyzer. 

* Fixed an issue where parent execution contexts were not properly capturing faulted child field execution pipeline results.

* Added unit tests to harness intended behavior for both changes


Fixes: #26 