### PR TITLE
Fixed a bug with required fields on input objects

### DIFF
--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/Common/DocumentPartValidationRuleStep{TContextItem}.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/Common/DocumentPartValidationRuleStep{TContextItem}.cs
@@ -18,12 +18,7 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.Common
     internal abstract class DocumentPartValidationRuleStep<TContextItem> : DocumentPartValidationRuleStep
         where TContextItem : class
     {
-        /// <summary>
-        /// Determines whether this instance can process the given context. The rule will have no effect on the node if it cannot
-        /// process it.
-        /// </summary>
-        /// <param name="context">The context that may be acted upon.</param>
-        /// <returns><c>true</c> if this instance can validate the specified document part; otherwise, <c>false</c>.</returns>
+        /// <inheritdoc />
         public override bool ShouldExecute(DocumentValidationContext context)
         {
             return context.Contains<TContextItem>();

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
@@ -20,12 +20,7 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.FieldSelect
     /// </summary>
     internal class Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField : DocumentPartValidationRuleStep<FieldSelection>
     {
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns><c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var fieldSelection = (FieldSelection)context.ActivePart;
@@ -51,18 +46,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.FieldSelect
             return allArgsValid;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.4.2.1";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-Required-Arguments";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
@@ -20,12 +20,7 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryDirect
     /// </summary>
     internal class Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective : DocumentPartValidationRuleStep<QueryDirective>
     {
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns><c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var queryDirective = (QueryDirective)context.ActivePart;
@@ -47,18 +42,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryDirect
             return directiveIsValid;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.4.2.1";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-Required-Arguments";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_4_AllDeclaredFragmentsMustBeUsed.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_4_AllDeclaredFragmentsMustBeUsed.cs
@@ -19,12 +19,7 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryFragme
     /// </summary>
     internal class Rule_5_5_1_4_AllDeclaredFragmentsMustBeUsed : DocumentPartValidationRuleStep<QueryFragment>
     {
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns><c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var fragment = (QueryFragment)context.ActivePart;
@@ -41,18 +36,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryFragme
             return true;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.5.1.4";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-Fragments-Must-Be-Used";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputArgumentSteps/Rule_5_8_5_VariableValueMustBeUsableInContext.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputArgumentSteps/Rule_5_8_5_VariableValueMustBeUsableInContext.cs
@@ -20,24 +20,13 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputA
     /// </summary>
     internal class Rule_5_8_5_VariableValueMustBeUsableInContext : DocumentPartValidationRuleStep
     {
-        /// <summary>
-        /// Determines whether this instance can process the given context. The rule will have no effect on the input argument if it cannot
-        /// process it.
-        /// </summary>
-        /// <param name="context">The context that may be acted upon.</param>
-        /// <returns><c>true</c> if this instance can validate the specified input argument; otherwise, <c>false</c>.</returns>
+        /// <inheritdoc />
         public override bool ShouldExecute(DocumentValidationContext context)
         {
             return context.ActivePart is QueryInputArgument arg && arg.Value is QueryVariableReferenceInputValue;
         }
 
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns>
-        ///   <c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var argument = context.ActivePart as QueryInputArgument;
@@ -60,18 +49,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputA
             return true;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.8.5";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-All-Variable-Usages-are-Allowed";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_1_ValueMustBeCoerceable.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_1_ValueMustBeCoerceable.cs
@@ -24,23 +24,13 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
     /// </summary>
     internal class Rule_5_6_1_ValueMustBeCoerceable : DocumentPartValidationRuleStep
     {
-        /// <summary>
-        /// Determines whether this instance can process the given context. The rule will have no effect on the input argument if it cannot
-        /// process it.
-        /// </summary>
-        /// <param name="context">The context that may be acted upon.</param>
-        /// <returns><c>true</c> if this instance can validate the specified input argument; otherwise, <c>false</c>.</returns>
+        /// <inheritdoc />
         public override bool ShouldExecute(DocumentValidationContext context)
         {
             return context.ActivePart is IInputValueDocumentPart ivdp && !(ivdp.Value is QueryVariableReferenceInputValue);
         }
 
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns><c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var ivdp = context.ActivePart as IInputValueDocumentPart;
@@ -204,18 +194,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
             return true;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.6.1";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-Values-of-Correct-Type";
     }
 }

--- a/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_4_InputObjectRequiredFieldsMustBeProvided.cs
+++ b/src/graphql-aspnet/ValidationRules/RuleSets/DocumentValidation/QueryInputValueSteps/Rule_5_6_4_InputObjectRequiredFieldsMustBeProvided.cs
@@ -22,31 +22,21 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
     /// </summary>
     internal class Rule_5_6_4_InputObjectRequiredFieldsMustBeProvided : DocumentPartValidationRuleStep
     {
-        /// <summary>
-        /// Determines whether this instance can process the given context. The rule will have no effect on the input argument if it cannot
-        /// process it.
-        /// </summary>
-        /// <param name="context">The context that may be acted upon.</param>
-        /// <returns><c>true</c> if this instance can validate the specified input argument; otherwise, <c>false</c>.</returns>
+        /// <inheritdoc />
         public override bool ShouldExecute(DocumentValidationContext context)
         {
             return context.ActivePart is IInputValueDocumentPart ivdp &&
                 ivdp.Value is QueryComplexInputValue;
         }
 
-        /// <summary>
-        /// Validates the completed document context to ensure it is "correct" against the specification before generating
-        /// the final document.
-        /// </summary>
-        /// <param name="context">The context containing the parsed sections of a query document..</param>
-        /// <returns><c>true</c> if the rule passes, <c>false</c> otherwise.</returns>
+        /// <inheritdoc />
         public override bool Execute(DocumentValidationContext context)
         {
             var ivdp = context.ActivePart as IInputValueDocumentPart;
             var graphType = ivdp.GraphType as IInputObjectGraphType;
             var requiredFields = graphType?.Fields.Where(x => x.TypeExpression.IsRequired).ToList();
             var complexValue = ivdp.Value as QueryComplexInputValue;
-            if (complexValue == null || requiredFields == null || !requiredFields.Any())
+            if (complexValue == null || requiredFields == null)
             {
                 this.ValidationError(
                     context,
@@ -72,18 +62,10 @@ namespace GraphQL.AspNet.ValidationRules.RuleSets.DocumentValidation.QueryInputV
             return allFieldsAccountedFor;
         }
 
-        /// <summary>
-        /// Gets the rule number being validated in this instance (e.g. "X.Y.Z"), if any.
-        /// </summary>
-        /// <value>The rule number.</value>
+        /// <inheritdoc />
         public override string RuleNumber => "5.6.4";
 
-        /// <summary>
-        /// Gets an anchor tag, pointing to a specific location on the webpage identified
-        /// as the specification supported by this library. If ReferenceUrl is overriden
-        /// this value is ignored.
-        /// </summary>
-        /// <value>The rule anchor tag.</value>
+        /// <inheritdoc />
         protected override string RuleAnchorTag => "#sec-Input-Object-Required-Fields";
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectController.cs
@@ -15,10 +15,22 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 
     public class ComplexInputObjectController : GraphController
     {
-        [MutationRoot(typeof(bool))]
+        [MutationRoot(typeof(ComplexInputObjectWithNoRequiredFields))]
         public IGraphActionResult AddObject(ComplexInputObjectWithNoRequiredFields objectA)
         {
-            return this.Ok(true);
+            return this.Ok(objectA);
+        }
+
+        [MutationRoot(typeof(ParentWithNullableChildObject))]
+        public IGraphActionResult ObjectWithNullChild(ParentWithNullableChildObject parentObj)
+        {
+            return this.Ok(parentObj);
+        }
+
+        [MutationRoot(typeof(ParentWithNonNullableChildObject))]
+        public IGraphActionResult ObjectWithNonNullChild(ParentWithNonNullableChildObject parentObj)
+        {
+            return this.Ok(parentObj);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Interfaces.Controllers;
+
+    public class ComplexInputObjectController : GraphController
+    {
+        [MutationRoot(typeof(bool))]
+        public IGraphActionResult AddObject(ComplexInputObjectWithNoRequiredFields objectA)
+        {
+            return this.Ok(true);
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectWithNoRequiredFields.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectWithNoRequiredFields.cs
@@ -1,11 +1,14 @@
-﻿namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
 
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
     public class ComplexInputObjectWithNoRequiredFields
     {
         public string Property1 { get; set; }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectWithNoRequiredFields.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ComplexInputObjectWithNoRequiredFields.cs
@@ -1,0 +1,15 @@
+﻿namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class ComplexInputObjectWithNoRequiredFields
+    {
+        public string Property1 { get; set; }
+
+        public string Property2 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/NullableChildObject.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/NullableChildObject.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    public class NullableChildObject
+    {
+        public string Property2 { get; set; }
+
+        public string Property3 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ParentWithNonNullableChildObject.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ParentWithNonNullableChildObject.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+
+    public class ParentWithNonNullableChildObject
+    {
+        public string Property1 { get; set; }
+
+        [GraphField(TypeExpression = TypeExpressions.IsNotNull)]
+        public NullableChildObject Child { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ParentWithNullableChildObject.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ParentWithNullableChildObject.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    public class ParentWithNullableChildObject
+    {
+        public string Property1 { get; set; }
+
+        public NullableChildObject Child { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -454,5 +454,27 @@ namespace GraphQL.AspNet.Tests.Execution
             Assert.IsFalse(result.Messages.IsSucessful);
             Assert.AreEqual(1, result.Messages.Count);
         }
+
+        [Test]
+        public async Task InputComplexObjects_WithNoRequiredFields_Succeeds()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // controller returns a list of {Value1, -3}
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { addObject ( objectA: {property1: \"prop1\", property2: \"prop2\" } )  }");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""addObject"" : true
+                    }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -464,12 +464,210 @@ namespace GraphQL.AspNet.Tests.Execution
 
             // controller accepts a complex input object with no required fields (just string values).
             var builder = server.CreateQueryContextBuilder()
-                .AddQueryText("mutation  { addObject ( objectA: {property1: \"prop1\", property2: \"prop2\" } )  }");
+                .AddQueryText("mutation  { " +
+                "   addObject ( objectA: {property1: \"prop1\", property2: \"prop2\" } ) { " +
+                "     property1 " +
+                "     property2 " +
+                "   } " +
+                "}");
 
             var expectedOutput =
                 @"{
                     ""data"": {
-                       ""addObject"" : true
+                       ""addObject"" : {
+                            ""property1"" : ""prop1"",
+                            ""property2"" : ""prop2""
+                        }
+                    }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task InputWithNullableComplexChildObject_HasUndefinedForChildObject_YieldsNullChildObject()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is not passed on the query
+            // the controller should recieve a null child object (not an empty one)
+            // and thus return null
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNullChild ( parentObj: {property1: \"prop1\" } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""objectWithNullChild"" : {
+                            ""property1"" : ""prop1"",
+                            ""child"" : null
+                       }
+                    }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task InputWithNullableComplexChildObject_HasNullPassedForChildObject_YieldsNullChildObject()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is not passed on the query
+            // the controller should recieve a null child object (not an empty one)
+            // and thus return null
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNullChild ( parentObj: {property1: \"prop1\", child : null } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""objectWithNullChild"" : {
+                            ""property1"" : ""prop1"",
+                            ""child"" : null
+                       }
+                    }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task InputWithNullableComplexChildObject_WhenChildObjectDefinedWithNoFieldsForChildObject_HasChildWithNullFields()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // child is passed as an empty object and has no required fields. All fields of child
+            // should be initialized to null and returnable (as null)
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNullChild ( parentObj: {property1: \"prop1\", child :{} } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""objectWithNullChild"" : {
+                            ""property1"" : ""prop1"",
+                            ""child"" : {
+                                 ""property2"" : null
+                            }
+                       }
+                    }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task InputWithNonNullableComplexChildObject_HasUndefinedForChildObject_YieldsError()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is not passed on the query
+            // but is required the query should fail
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNonNullChild ( parentObj: {property1: \"prop1\" } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var result = await server.ExecuteQuery(builder);
+
+            Assert.IsFalse(result.Messages.IsSucessful);
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_DOCUMENT, result.Messages[0].Code);
+        }
+
+        [Test]
+        public async Task InputWithNonNullableComplexChildObject_HasNullForChildObject_YieldsError()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as null on the query
+            // but is required the query should fail
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNonNullChild ( parentObj: {property1: \"prop1\", child : null } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var result = await server.ExecuteQuery(builder);
+
+            Assert.IsFalse(result.Messages.IsSucessful);
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_DOCUMENT, result.Messages[0].Code);
+        }
+
+        [Test]
+        public async Task InputWithNonNullableComplexChildObject_HasEmptyForChildObject_YieldsSuccess()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ComplexInputObjectController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("mutation  { " +
+                "      objectWithNonNullChild ( parentObj: {property1: \"prop1\", child : {} } ) { " +
+                "           property1 " +
+                "           child {" +
+                "               property2 " +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""objectWithNonNullChild"" : {
+                            ""property1"" : ""prop1"",
+                            ""child"" : {
+                                 ""property2"" : null
+                            }
+                       }
                     }
                   }";
 

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -462,7 +462,7 @@ namespace GraphQL.AspNet.Tests.Execution
                     .AddGraphType<ComplexInputObjectController>()
                     .Build();
 
-            // controller returns a list of {Value1, -3}
+            // controller accepts a complex input object with no required fields (just string values).
             var builder = server.CreateQueryContextBuilder()
                 .AddQueryText("mutation  { addObject ( objectA: {property1: \"prop1\", property2: \"prop2\" } )  }");
 


### PR DESCRIPTION
* Fixed a bug where `INPUT_OBJECT` types were required to have at least 1 non-nullable field such as a number.  They can no have 0 or more required fields.
* Added appropriate unit tests to prevent future regression
* Additional clean up some comments with `<inheritdoc />` statements for nearby rules