### PR TITLE
Updated GraphValidation to recognize an array as a valid list type

### DIFF
--- a/src/graphql-aspnet/Common/Extensions/TypeExtensions.cs
+++ b/src/graphql-aspnet/Common/Extensions/TypeExtensions.cs
@@ -192,6 +192,7 @@ namespace GraphQL.AspNet.Common.Extensions
             }
 
             // if the type implements IEnumerable<> grab that interface then return its argument
+            // this will capture flat arrays and any custom object that implements IEnumerable<T>
             var enumerableInterface = type.GetInterface(typeof(IEnumerable<>).Name);
             if (enumerableInterface != null)
             {

--- a/src/graphql-aspnet/Internal/GraphValidation.cs
+++ b/src/graphql-aspnet/Internal/GraphValidation.cs
@@ -215,15 +215,16 @@ namespace GraphQL.AspNet.Internal
             if (type == null || type == typeof(string))
                 return false;
 
-            // all lists must be declared as generics to allow for type declaration and parsing.
-            if (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type))
-            {
-                Type enumerableType = type.GetEnumerableUnderlyingType();
-                return !enumerableType.IsGenericType || !typeof(KeyValuePair<,>)
-                    .IsAssignableFrom(enumerableType.GetGenericTypeDefinition());
-            }
+            if (!typeof(IEnumerable).IsAssignableFrom(type))
+                return false;
 
-            return false;
+            var enumerableType = type.GetEnumerableUnderlyingType();
+            if (enumerableType == null)
+                return false;
+
+            return
+                !enumerableType.IsGenericType ||
+                !typeof(KeyValuePair<,>).IsAssignableFrom(enumerableType.GetGenericTypeDefinition());
         }
 
         /// <summary>

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayAsEnumerableController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayAsEnumerableController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayAsEnumerableController : GraphIdController
+    {
+        [QueryRoot]
+        public IEnumerable<TwoPropertyObject> RetrieveData()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
@@ -1,0 +1,43 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayOnReturnObjectMethodController : GraphIdController
+    {
+        [QueryRoot]
+        public ArrayObject RetrieveData()
+        {
+            return
+                new ArrayObject()
+                {
+                    PropertyA = "AA",
+                };
+        }
+
+        public class ArrayObject
+        {
+            public string PropertyA { get; set; }
+
+            [GraphField]
+            public TwoPropertyObject[] MoreData()
+            {
+                return new TwoPropertyObject[2]
+                    {
+                        new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                        new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+                    };
+            }
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
@@ -1,0 +1,43 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using System.Security.Policy;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayOnReturnObjectPropertyController : GraphIdController
+    {
+        [QueryRoot]
+        public IEnumerable<ArrayObject> RetrieveData()
+        {
+            return new ArrayObject[1]
+            {
+                new ArrayObject()
+                {
+                    PropertyA = "AA",
+                    PropertyB = new TwoPropertyObject[2]
+                    {
+                        new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                        new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+                    },
+                },
+            };
+        }
+
+        public class ArrayObject
+        {
+            public string PropertyA { get; set; }
+
+            public TwoPropertyObject[] PropertyB { get; set; }
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
@@ -1,0 +1,25 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayScalarController : GraphIdController
+    {
+        [QueryRoot(typeof(IEnumerable<int>))]
+        public IGraphActionResult RetrieveData()
+        {
+            return this.Ok(new int[] { 1, 3, 5 });
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayThroughArrayDeclarationController : GraphIdController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveData()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughGraphActionAsEnumerableController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughGraphActionAsEnumerableController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayThroughGraphActionAsEnumerableController : GraphIdController
+    {
+        [QueryRoot(typeof(IEnumerable<TwoPropertyObject>))]
+        public IGraphActionResult RetrieveData()
+        {
+            return this.Ok(new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            });
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -674,5 +674,229 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
         }
+
+        [Test]
+        public async Task ControllerReturnsAnarrayForAnEnumerableDeclarartion_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayAsEnumerableController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task ControllerReturnsAnArrayForAnArrayThroughGraphActionDeclarartion_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayThroughGraphActionAsEnumerableController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task ControllerReturnsAnArrayForAnArrayDeclaration_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayThroughArrayDeclarationController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_AsProperty_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayOnReturnObjectPropertyController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           propertyA " +
+                "           propertyB {" +
+                "               property1" +
+                "               property2" +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""propertyA"" : ""AA"",
+                                ""propertyB"" : [
+                                    {
+                                        ""property1"" : ""1A"",
+                                        ""property2"" : 2
+                                    },
+                                    {
+                                        ""property1"" : ""1B"",
+                                        ""property2"" : 3
+                                    }
+                                ]
+                            },
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_AsObjectMethod_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayOnReturnObjectMethodController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           propertyA " +
+                "           moreData() {" +
+                "               property1" +
+                "               property2" +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : {
+                            ""propertyA"" : ""AA"",
+                            ""moreData"" : [
+                                {
+                                    ""property1"" : ""1A"",
+                                    ""property2"" : 2
+                                },
+                                {
+                                    ""property1"" : ""1B"",
+                                    ""property2"" : 3
+                                }
+                            ]
+                         }
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_OfScalard_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayScalarController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [1, 3, 5]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithNoSecurityPolicies.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithNoSecurityPolicies.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.GraphValidationTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class ControllerWithNoSecurityPolicies : GraphController
+    {
+        [QueryRoot]
+        public int SomeMethod()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithSecurityPolicies.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithSecurityPolicies.cs
@@ -1,0 +1,25 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.GraphValidationTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using Microsoft.AspNetCore.Authorization;
+
+    public class ControllerWithSecurityPolicies : GraphController
+    {
+        [Authorize]
+        [QueryRoot]
+        public int SomeMethod()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -10,12 +10,15 @@
 namespace GraphQL.AspNet.Tests.Internal
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.Interfaces;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Internal.GraphValidationTestData;
     using Moq;
     using NUnit.Framework;
     using GTW = GraphQL.AspNet.Schemas.TypeSystem.MetaGraphTypes;
@@ -23,6 +26,12 @@ namespace GraphQL.AspNet.Tests.Internal
     [TestFixture]
     public class GraphValidationTests
     {
+        public enum ValidationTestEnum
+        {
+            Value1,
+            Value2,
+        }
+
         [TestCase(typeof(IEnumerable<int>), true)]
         [TestCase(typeof(ICollection<int>), true)]
         [TestCase(typeof(IList<int>), true)]
@@ -36,6 +45,14 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(Dictionary<string, int>), false)]
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
+        [TestCase(typeof(TwoPropertyObject[]), true)]
+        [TestCase(typeof(int[]), true)]
+        [TestCase(typeof(string[]), true)]
+        [TestCase(typeof(DateTime[]), true)]
+        [TestCase(typeof(ValidationTestEnum[]), true)]
+        [TestCase(typeof(KeyValuePair<string, string>[]), false)]
+        [TestCase(typeof(KeyValuePair<string, TwoPropertyObject>[]), false)]
+        [TestCase(typeof(KeyValuePair<string, int>[]), false)]
         public void IsValidListType(Type inputType, bool isValidListType)
         {
             var result = GraphValidation.IsValidListType(inputType);
@@ -49,12 +66,17 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(List<string>), true)]
         [TestCase(typeof(List<DateTime>), true)]
         [TestCase(typeof(List<TwoPropertyObject>), true)]
+        [TestCase(typeof(TwoPropertyObject[]), true)]
+        [TestCase(typeof(int[]), true)]
+        [TestCase(typeof(string[]), true)]
+        [TestCase(typeof(DateTime[]), true)]
         [TestCase(typeof(string), true)]
         [TestCase(typeof(int), true)]
         [TestCase(typeof(DateTime), true)]
         [TestCase(typeof(Dictionary<string, int>), false)]
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
+        [TestCase(typeof(object), false)]
         public void IsValidGraphType(Type inputType, bool isValidType)
         {
             var result = GraphValidation.IsValidGraphType(inputType);
@@ -71,6 +93,12 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(int), "int!", false, null)]
         [TestCase(typeof(int), "int", true, null)]
         [TestCase(typeof(IEnumerable<int>), "[int!]", false, null)]
+        [TestCase(typeof(int[]), "[int!]", false, null)]
+        [TestCase(typeof(IEnumerable<TwoPropertyObject>), "[TwoPropertyObject]", false, null)]
+        [TestCase(typeof(TwoPropertyObject[]), "[TwoPropertyObject]", true, null)]
+        [TestCase(typeof(TwoPropertyObject[]), "[TwoPropertyObject]", false, null)]
+        [TestCase(typeof(int[][]), "[[int!]]", false, null)]
+        [TestCase(typeof(string[]), "[string]", false, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "[[int!]]", false, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "int!", false, new GTW[] { GTW.IsNotNull })]
         public void GenerateTypeExpression(
@@ -85,6 +113,57 @@ namespace GraphQL.AspNet.Tests.Internal
 
             var typeExpression = GraphValidation.GenerateTypeExpression(type, mock.Object);
             Assert.AreEqual(expectedExpression, typeExpression.ToString());
+        }
+
+        [TestCase(typeof(int), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int>), typeof(Task<int>), true, false, true)]
+        [TestCase(typeof(int?), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<List<int?>>), typeof(int), true, true, true)]
+        [TestCase(typeof(List<int>), typeof(int), true, true, true)]
+        [TestCase(typeof(int?), typeof(int?), true, true, false)]
+        [TestCase(typeof(int[]), typeof(int), true, true, true)]
+        [TestCase(typeof(int[]), typeof(int[]), false, true, true)]
+        [TestCase(typeof(string[]), typeof(string), true, true, true)]
+        [TestCase(typeof(Task<int[]>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?[]>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?[]>), typeof(int?), true, true, false)]
+        [TestCase(typeof(Task<int?[]>), typeof(Task<int?[]>), true, false, true)]
+        public void EliminateWrappersFromCoreType(
+            Type typeToTest,
+            Type expectedCoreType,
+            bool removeEnumerables,
+            bool removeTask,
+            bool removeNullableT)
+        {
+            var result = GraphValidation.EliminateWrappersFromCoreType(typeToTest, removeEnumerables, removeTask, removeNullableT);
+            Assert.AreEqual(expectedCoreType, result);
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_NullAttributeProvider_YieldsNoPolicies()
+        {
+            var policies = GraphValidation.RetrieveSecurityPolicies(null);
+            Assert.AreEqual(0, policies.Count());
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_MethodWithNoSecurityPolicies_ReturnsEmptyEnumerable()
+        {
+            var info = typeof(ControllerWithNoSecurityPolicies).GetMethod(nameof(ControllerWithNoSecurityPolicies.SomeMethod));
+
+            var policies = GraphValidation.RetrieveSecurityPolicies(info);
+            Assert.AreEqual(0, policies.Count());
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_MethodWithSecurityPolicies_ReturnsOneItem()
+        {
+            var info = typeof(ControllerWithSecurityPolicies).GetMethod(nameof(ControllerWithSecurityPolicies.SomeMethod));
+
+            var policies = GraphValidation.RetrieveSecurityPolicies(info);
+            Assert.AreEqual(1, policies.Count());
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ArrayReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ArrayReturnController.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class ArrayReturnController : GraphController
+    {
+        [QueryRoot]
+        public string[] RetrieveData()
+        {
+            return new string[0];
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
@@ -12,8 +12,12 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using System.Linq;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using NUnit.Framework;
 
     [TestFixture]
@@ -48,6 +52,23 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[mutation]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[query]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/TwoPropertyObject/Property3"));
+        }
+
+        [Test]
+        public void Parse_ReturnArrayOnAction_ParsesCorrectly()
+        {
+            var expectedTypeExpression = new GraphTypeExpression(
+                "String",
+                MetaGraphTypes.IsList);
+
+            var template = GraphQLProviders.TemplateProvider.ParseType<ArrayReturnController>() as GraphControllerTemplate;
+            Assert.IsNotNull(template);
+
+            Assert.AreEqual(1, template.Actions.Count());
+
+            var action = template.Actions.ElementAt(0);
+            Assert.AreEqual(typeof(string[]), action.DeclaredReturnType);
+            Assert.AreEqual(expectedTypeExpression, action.TypeExpression);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
@@ -12,11 +12,13 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.MethodTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
 
@@ -164,6 +166,25 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
         {
             var template = this.CreateMethodTemplate<MethodClass>(nameof(MethodClass.TaskOfListOfObjectReturnType));
             Assert.AreEqual(typeof(TwoPropertyObject), template.ObjectType);
+        }
+
+
+        [Test]
+        public void Parse_ArrayFromMethod_YieldsTemplate()
+        {
+            var obj = new Mock<IObjectGraphTypeTemplate>();
+            obj.Setup(x => x.Route).Returns(new GraphFieldPath("[type]/Item0"));
+            obj.Setup(x => x.InternalFullName).Returns("Item0");
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            var parent = obj.Object;
+            var template = this.CreateMethodTemplate<ArrayMethodObject>(nameof(ArrayMethodObject.RetrieveData));
+
+            Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
+            Assert.AreEqual(typeof(TwoPropertyObject[]), template.DeclaredReturnType);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
@@ -15,8 +15,12 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests;
+    using GraphQL.AspNet.Common.Extensions;
     using NUnit.Framework;
+    using GraphQL.AspNet.Schemas.TypeSystem;
 
     [TestFixture]
     public class GraphObjectTemplateTests
@@ -172,6 +176,28 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             // should have the declared method, the undeclared but valid method, the decalred property
             // the invalid undeclared method should be dropped silently
             Assert.AreEqual(3, template.FieldTemplates.Count);
+        }
+
+        [Test]
+        public void Parse_ArrayProperty_ExtractsListOfCoreType()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(TypeWithArrayProperty));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            // should have the declared method, the undeclared but valid method, the decalred property
+            // the invalid undeclared method should be dropped silently
+            Assert.AreEqual(1, template.FieldTemplates.Count);
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            Assert.AreEqual(1, template.FieldTemplates.Count());
+            var fieldTemplate = template.FieldTemplates.ElementAt(0).Value;
+            Assert.AreEqual(typeof(TwoPropertyObject[]), fieldTemplate.DeclaredReturnType);
+            Assert.AreEqual(typeof(TwoPropertyObject), fieldTemplate.ObjectType);
+            Assert.AreEqual(expectedTypeExpression, fieldTemplate.TypeExpression);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
@@ -13,9 +13,13 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests;
     using GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
 
@@ -159,6 +163,28 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             {
                 template.ValidateOrThrow();
             });
+        }
+
+        [Test]
+        public void Parse_BasicObject_PropertyReturnsArray_YieldsTemplate()
+        {
+            var obj = new Mock<IObjectGraphTypeTemplate>();
+            obj.Setup(x => x.Route).Returns(new GraphFieldPath("[type]/Item0"));
+            obj.Setup(x => x.InternalFullName).Returns("Item0");
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            var parent = obj.Object;
+            var propInfo = typeof(ArrayPropertyObject).GetProperty(nameof(ArrayPropertyObject.PropertyA));
+
+            var template = new PropertyGraphFieldTemplate(parent, propInfo, TypeKind.OBJECT);
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
+            Assert.AreEqual(typeof(TwoPropertyObject[]), template.DeclaredReturnType);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/ArrayMethodObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/ArrayMethodObject.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.MethodTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayMethodObject
+    {
+        [GraphField]
+        public TwoPropertyObject[] RetrieveData()
+        {
+            return null;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeWithArrayProperty.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeWithArrayProperty.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class TypeWithArrayProperty
+    {
+        public TwoPropertyObject[] PropertyA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayPropertyObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayPropertyObject.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayPropertyObject
+    {
+        public TwoPropertyObject[] PropertyA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
@@ -634,5 +634,102 @@ namespace GraphQL.AspNet.Tests.Schemas
                 manager.EnsureGraphType<ControllerWithRootName2>();
             });
         }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerReturnTypeIsGraphTypeIsAFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayReturnController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerReturnTypeDeclarationIsGraphTypeIsAFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayReturnDeclarationController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerInputTypeIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayObjectInputController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.INPUT_OBJECT));
+
+            Assert.IsFalse(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.OBJECT));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerInputTypeIsFlatArrayAndReturnsFlatArray_ArrayIsAddedAsInputAndReturnType()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayInputAndReturnController>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.INPUT_OBJECT));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenPropertyIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayPropertyObject>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(ArrayPropertyObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenMethodReturnIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayMethodObject>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(ArrayMethodObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayInputAndReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayInputAndReturnController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayInputAndReturnController : GraphController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveArray(TwoPropertyObject[] items)
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayMethodObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayMethodObject.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayMethodObject
+    {
+        [GraphField]
+        public TwoPropertyObject[] SubData()
+        {
+            return null;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayObjectInputController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayObjectInputController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayObjectInputController : GraphController
+    {
+        [QueryRoot]
+        public string ArrayIn(TwoPropertyObject[] inputObjects)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayPropertyObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayPropertyObject.cs
@@ -1,0 +1,20 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayPropertyObject
+    {
+        public string Prop1 { get; set; }
+
+        public TwoPropertyObject[] Prop2 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayReturnController : GraphController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveArray()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnDeclarationController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnDeclarationController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayReturnDeclarationController : GraphController
+    {
+        [QueryRoot(typeof(TwoPropertyObject[]))]
+        public IGraphActionResult RetrieveArray()
+        {
+            return this.Ok(new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            });
+        }
+    }
+}


### PR DESCRIPTION
* Fixed a bug in `GraphValidation.IsValidListType` to recognize a flat array (e.g. `MyObject[]`) as a valid list type and allow them to be declared types in an object graph
  * This was an underlying issue that was causing validation rule `6.4.3` to fail when an array is supplied to an `IEnumerable<T>` type declaration at runtime
* Added a multitude of new tests at all levels to ensure flat arrays are recognized as list types for various template operations:
  * object properties
  * object methods
  * input types,
  * controller return types
  * controller return types when using `IGraphActionResult`
 * Added unit tests to ensure proper execution and run-time rule validation as well