### PR TITLE
Added Flat Arrays as valid Graph Types. Enabled .net ValueTypes as OBJECT graph types

### DIFF
--- a/src/graphql-aspnet/Common/Extensions/TypeExtensions.cs
+++ b/src/graphql-aspnet/Common/Extensions/TypeExtensions.cs
@@ -192,6 +192,7 @@ namespace GraphQL.AspNet.Common.Extensions
             }
 
             // if the type implements IEnumerable<> grab that interface then return its argument
+            // this will capture flat arrays and any custom object that implements IEnumerable<T>
             var enumerableInterface = type.GetInterface(typeof(IEnumerable<>).Name);
             if (enumerableInterface != null)
             {

--- a/src/graphql-aspnet/Defaults/DefaultGraphLogger.cs
+++ b/src/graphql-aspnet/Defaults/DefaultGraphLogger.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Defaults
 {
     using System;
-    using System.Security.Claims;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.InputModel;
     using GraphQL.AspNet.Interfaces.Execution;

--- a/src/graphql-aspnet/Execution/Metrics/ApolloTracingMetricsV1.cs
+++ b/src/graphql-aspnet/Execution/Metrics/ApolloTracingMetricsV1.cs
@@ -20,7 +20,6 @@ namespace GraphQL.AspNet.Execution.Metrics
     using GraphQL.AspNet.Interfaces.TypeSystem;
     using GraphQL.AspNet.Middleware.FieldExecution;
     using GraphQL.AspNet.Response;
-    using GraphQL.AspNet.Schemas;
 
     /// <summary>
     /// A metrics package that tracks according to the apollo tracing standard.

--- a/src/graphql-aspnet/Internal/GraphTypeNames.cs
+++ b/src/graphql-aspnet/Internal/GraphTypeNames.cs
@@ -144,7 +144,7 @@ namespace GraphQL.AspNet.Internal
                 }
             }
 
-            typeName = typeName ?? type.FriendlyName("_");
+            typeName = typeName ?? type.FriendlyGraphTypeName();
             typeName = typeName.Replace(Constants.Routing.CLASS_META_NAME, type.Name).Trim();
             if (kind == TypeKind.DIRECTIVE && typeName.EndsWith(Constants.CommonSuffix.DIRECTIVE_SUFFIX))
             {
@@ -153,6 +153,17 @@ namespace GraphQL.AspNet.Internal
 
             AssignName(type, kind, typeName);
             return typeName;
+        }
+
+        /// <summary>
+        /// Creates friendly name for a type that can be considered a valid name of a GraphQL graph type.
+        /// This method does not take into account any scheme specific naming or casing rules.
+        /// </summary>
+        /// <param name="type">The type to create a friendly Name for.</param>
+        /// <returns>System.String.</returns>
+        public static string FriendlyGraphTypeName(this Type type)
+        {
+            return type.FriendlyName("_");
         }
     }
 }

--- a/src/graphql-aspnet/Internal/GraphValidation.cs
+++ b/src/graphql-aspnet/Internal/GraphValidation.cs
@@ -215,15 +215,16 @@ namespace GraphQL.AspNet.Internal
             if (type == null || type == typeof(string))
                 return false;
 
-            // all lists must be declared as generics to allow for type declaration and parsing.
-            if (type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type))
-            {
-                Type enumerableType = type.GetEnumerableUnderlyingType();
-                return !enumerableType.IsGenericType || !typeof(KeyValuePair<,>)
-                    .IsAssignableFrom(enumerableType.GetGenericTypeDefinition());
-            }
+            if (!typeof(IEnumerable).IsAssignableFrom(type))
+                return false;
 
-            return false;
+            var enumerableType = type.GetEnumerableUnderlyingType();
+            if (enumerableType == null)
+                return false;
+
+            return
+                !enumerableType.IsGenericType ||
+                !typeof(KeyValuePair<,>).IsAssignableFrom(enumerableType.GetGenericTypeDefinition());
         }
 
         /// <summary>

--- a/src/graphql-aspnet/Internal/TypeTemplates/BaseObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/BaseObjectGraphTypeTemplate.cs
@@ -10,6 +10,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Linq;
@@ -54,13 +55,24 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             // customize the error message on the thrown exception for some helpful hints.
             string rejectionReason = null;
             if (objectType.IsEnum)
-                rejectionReason = $"The type '{objectType.FriendlyName()}' is an enumeration and cannot be parsed as an object graph type. Use an {typeof(IEnumGraphType).FriendlyName()} instead.";
+            {
+                rejectionReason = $"The type '{objectType.FriendlyName()}' is an enumeration and cannot be parsed as an {nameof(TypeKind.OBJECT)} graph type. Use an {typeof(IEnumGraphType).FriendlyName()} instead.";
+            }
             else if (objectType.IsValueType)
-                rejectionReason = $"The type '{objectType.FriendlyName()}' is a value type and cannot be parsed as a graph type. Try using a scalar instead.";
+            {
+                if (GraphQLProviders.ScalarProvider.IsScalar(objectType))
+                {
+                    rejectionReason = $"The type '{objectType.FriendlyName()}' is a registered {nameof(TypeKind.SCALAR)} and cannot be parsed as an {nameof(TypeKind.OBJECT)} graph type. Try using the scalar definition instead.";
+                }
+            }
             else if (objectType == typeof(string))
-                rejectionReason = $"The type '{typeof(string).FriendlyName()}' cannot be parsed as an object graph type. Use the built in scalar instead.";
+            {
+                rejectionReason = $"The type '{typeof(string).FriendlyName()}' cannot be parsed as an {nameof(TypeKind.OBJECT)} graph type. Use the built in scalar instead.";
+            }
             else if (objectType.IsAbstract && objectType.IsClass)
-                rejectionReason = $"The type '{objectType.FriendlyName()}' is abstract and cannot be parsed as a graph type.";
+            {
+                rejectionReason = $"The type '{objectType.FriendlyName()}' is abstract and cannot be parsed as an {nameof(TypeKind.OBJECT)} graph type.";
+            }
 
             if (rejectionReason != null)
             {

--- a/src/graphql-aspnet/Internal/TypeTemplates/BaseObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/BaseObjectGraphTypeTemplate.cs
@@ -10,7 +10,6 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Linq;

--- a/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
@@ -31,13 +31,6 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         public ObjectGraphTypeTemplate(Type objectType)
             : base(objectType)
         {
-            if (!objectType.IsClass)
-            {
-                throw new GraphTypeDeclarationException(
-                    $"The type '{objectType.FriendlyName()}' is not a class and " +
-                    $"cannot be parsed as an {nameof(TypeKind.OBJECT)} graph type.",
-                    objectType);
-            }
         }
 
         /// <summary>

--- a/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
@@ -11,8 +11,6 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
 {
     using System;
     using System.Diagnostics;
-    using GraphQL.AspNet.Common.Extensions;
-    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.TypeSystem;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Schemas.TypeSystem;

--- a/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
@@ -20,7 +20,6 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
     using GraphQL.AspNet.Common.Generics;
     using GraphQL.AspNet.Common.Source;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Execution.FieldResolution;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Middleware;

--- a/src/graphql-aspnet/Schemas/GraphTypeExpression.cs
+++ b/src/graphql-aspnet/Schemas/GraphTypeExpression.cs
@@ -13,8 +13,10 @@ namespace GraphQL.AspNet.Schemas
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Parsing.Lexing.Tokens;
     using GraphQL.AspNet.Schemas.TypeSystem;
+    using Microsoft.Extensions.Logging.Abstractions.Internal;
 
     /// <summary>
     /// A declaration of the usage of a single graph type (with appropriate wrappers).

--- a/src/graphql-aspnet/Schemas/GraphTypeExpression.cs
+++ b/src/graphql-aspnet/Schemas/GraphTypeExpression.cs
@@ -13,10 +13,8 @@ namespace GraphQL.AspNet.Schemas
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
-    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Parsing.Lexing.Tokens;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using Microsoft.Extensions.Logging.Abstractions.Internal;
 
     /// <summary>
     /// A declaration of the usage of a single graph type (with appropriate wrappers).

--- a/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloClientProxyTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloClientProxyTests.cs
@@ -11,19 +11,14 @@ namespace GraphQL.Subscriptions.Tests.Apollo
 {
     using System;
     using System.Linq;
-    using System.Net.Sockets;
-    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using GraphQL.AspNet;
     using GraphQL.AspNet.Apollo;
     using GraphQL.AspNet.Apollo.Messages;
     using GraphQL.AspNet.Apollo.Messages.ClientMessages;
-    using GraphQL.AspNet.Apollo.Messages.Common;
     using GraphQL.AspNet.Apollo.Messages.Converters;
     using GraphQL.AspNet.Apollo.Messages.ServerMessages;
     using GraphQL.AspNet.Configuration;
-    using GraphQL.AspNet.Connections.Clients;
-    using GraphQL.AspNet.Execution.Subscriptions;
     using GraphQL.AspNet.Interfaces.Subscriptions;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
@@ -33,9 +28,7 @@ namespace GraphQL.Subscriptions.Tests.Apollo
     using GraphQL.Subscriptions.Tests.Apollo.ApolloTestData;
     using GraphQL.Subscriptions.Tests.TestServerExtensions;
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
     using NUnit.Framework;
-    using NUnit.Framework.Internal.Execution;
 
     [TestFixture]
     public partial class ApolloClientProxyTests

--- a/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloConverterTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloConverterTests.cs
@@ -14,7 +14,6 @@ namespace GraphQL.Subscriptions.Tests.Apollo
     using System.Threading.Tasks;
     using GraphQL.AspNet;
     using GraphQL.AspNet.Apollo.Messages;
-    using GraphQL.AspNet.Apollo.Messages.ClientMessages;
     using GraphQL.AspNet.Apollo.Messages.Converters;
     using GraphQL.AspNet.Apollo.Messages.ServerMessages;
     using GraphQL.AspNet.Execution;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloLoggingTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloLoggingTests.cs
@@ -14,7 +14,6 @@ namespace GraphQL.Subscriptions.Tests.Apollo
     using GraphQL.AspNet.Apollo;
     using GraphQL.AspNet.Apollo.Logging.ApolloEvents;
     using GraphQL.AspNet.Apollo.Messages.ClientMessages;
-    using GraphQL.AspNet.Apollo.Messages.Common;
     using GraphQL.AspNet.Apollo.Messages.ServerMessages;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Configuration;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloSubscriptionCollectionTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Apollo/ApolloSubscriptionCollectionTests.cs
@@ -15,7 +15,6 @@ namespace GraphQL.Subscriptions.Tests.Apollo
     using GraphQL.AspNet.Interfaces.Subscriptions;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
-    using Microsoft.Extensions.FileProviders;
     using Moq;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-subscriptions-tests/Attributes/SubscriptionAttributeTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Attributes/SubscriptionAttributeTests.cs
@@ -12,7 +12,6 @@ namespace GraphQL.Subscriptions.Tests.Attributes
     using GraphQL.AspNet;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-subscriptions-tests/Configuration/SubscriptionServerOptionsTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Configuration/SubscriptionServerOptionsTests.cs
@@ -9,8 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Configuration
 {
-    using System.Dynamic;
-    using System.Threading.Tasks;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Schemas;
     using NUnit.Framework;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Connections/WebSocketFailureResultTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Connections/WebSocketFailureResultTests.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Connections
 {
-    using System.Net.Sockets;
     using System.Net.WebSockets;
     using GraphQL.AspNet.Connections.Clients;
     using GraphQL.AspNet.Connections.WebSockets;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Controllers/ControllerExtensionTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Controllers/ControllerExtensionTests.cs
@@ -20,7 +20,6 @@ namespace GraphQL.Subscriptions.Tests.Controllers
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.Subscriptions.Tests.Controllers.ControllerTestData;
     using NUnit.Framework;
-    using NUnit.Framework.Internal.Execution;
 
     [TestFixture]
     public class ControllerExtensionTests

--- a/src/tests/graphql-aspnet-subscriptions-tests/Controllers/ControllerTestData/InvokableController.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Controllers/ControllerTestData/InvokableController.cs
@@ -9,8 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Controllers.ControllerTestData
 {
-    using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Defaults/HttpSubscriptionMiddlewareTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Defaults/HttpSubscriptionMiddlewareTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.Subscriptions.Tests.Defaults
     using System.Collections.Generic;
     using System.Net;
     using System.Net.WebSockets;
-    using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Defaults;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Execution/ClientSubscriptionTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Execution/ClientSubscriptionTests.cs
@@ -9,10 +9,8 @@
 
 namespace GraphQL.Subscriptions.Tests.Execution
 {
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using Castle.DynamicProxy.Generators;
     using GraphQL.AspNet;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Subscriptions;
@@ -23,10 +21,8 @@ namespace GraphQL.Subscriptions.Tests.Execution
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.Subscriptions.Tests.Execution.ClientSubscriptionTestData;
     using GraphQL.Subscriptions.Tests.TestServerExtensions;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
     using Moq;
     using NUnit.Framework;
-    using NUnit.Framework.Internal;
 
     [TestFixture]
     public class ClientSubscriptionTests

--- a/src/tests/graphql-aspnet-subscriptions-tests/Execution/SubscriptionEventNameTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Execution/SubscriptionEventNameTests.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Execution
 {
-    using System;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Execution.Subscriptions;
     using GraphQL.AspNet.Schemas;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Execution/SubscriptionQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Execution/SubscriptionQueryExecutionTests.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.Subscriptions.Tests.Execution
 {
     using System.Threading.Tasks;
-    using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.Subscriptions.Tests.Execution.SubscriptionQueryExecutionData;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Internal/Templating/ActionTestData/OneMethodSubscriptionController.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Internal/Templating/ActionTestData/OneMethodSubscriptionController.cs
@@ -10,10 +10,8 @@
 namespace GraphQL.Subscriptions.Tests.Internal.Templating.ActionTestData
 {
     using System.ComponentModel;
-    using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Interfaces.Controllers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class OneMethodSubscriptionController : GraphController

--- a/src/tests/graphql-aspnet-subscriptions-tests/Internal/Templating/GraphControllerTemplateTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Internal/Templating/GraphControllerTemplateTests.cs
@@ -10,11 +10,9 @@
 namespace GraphQL.Subscriptions.Tests.Internal.Templating
 {
     using System.Linq;
-    using GraphQL.AspNet;
     using GraphQL.AspNet.Defaults;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Internal.TypeTemplates;
-    using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.Subscriptions.Tests.Internal.Templating.ControllerTestData;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-subscriptions-tests/Logging/EventIdTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Logging/EventIdTests.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Logging
 {
-    using System;
     using System.Collections.Generic;
     using System.Reflection;
     using GraphQL.AspNet.Logging;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Schemas/GraphSchemaManagerTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Schemas/GraphSchemaManagerTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.Subscriptions.Tests.Schemas
     using GraphQL.AspNet;
     using GraphQL.AspNet.Defaults;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.TypeSystem;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Tests.Framework;

--- a/src/tests/graphql-aspnet-subscriptions-tests/Security/SecurityTestData/SubscriptionSecureWidget.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Security/SecurityTestData/SubscriptionSecureWidget.cs
@@ -9,8 +9,6 @@
 
 namespace GraphQL.Subscriptions.Tests.Security.SecurityTestData
 {
-    using Microsoft.AspNetCore.Authorization;
-
     public class SubscriptionSecureWidget
     {
         public string Id { get; set; }

--- a/src/tests/graphql-aspnet-subscriptions-tests/Security/SubscriptionPerRequestAuthorizationTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/Security/SubscriptionPerRequestAuthorizationTests.cs
@@ -11,11 +11,9 @@ namespace GraphQL.Subscriptions.Tests.Security
 {
     using System.Threading.Tasks;
     using GraphQL.AspNet;
-    using GraphQL.AspNet.Apollo.Exceptions;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.Subscriptions.Tests.Security.SecurityTestData;
     using GraphQL.Subscriptions.Tests.TestServerExtensions;
-    using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/tests/graphql-aspnet-subscriptions-tests/SubscriptionPublisherExtensionTests.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/SubscriptionPublisherExtensionTests.cs
@@ -9,12 +9,10 @@
 
 namespace GraphQL.Subscriptions.Tests
 {
-    using System.Linq;
     using GraphQL.AspNet;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Defaults;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Interfaces.Subscriptions;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Tests.Framework;
     using NUnit.Framework;

--- a/src/tests/graphql-aspnet-subscriptions-tests/TestServerExtensions/MockClientAsserts.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/TestServerExtensions/MockClientAsserts.cs
@@ -9,14 +9,11 @@
 
 namespace GraphQL.Subscriptions.Tests.TestServerExtensions
 {
-    using System;
     using System.Text;
     using System.Text.Json;
     using GraphQL.AspNet.Apollo.Messages;
-    using GraphQL.AspNet.Apollo.Messages.ServerMessages;
     using GraphQL.AspNet.Tests.Framework.Clients;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
-    using GraphQL.Subscriptions.Tests.Apollo.ApolloTestData;
     using GraphQL.Subscriptions.Tests.TestServerExtensions.ApolloMessaging;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-subscriptions-tests/TestServerExtensions/TestServerSubscriptionHelpers.cs
+++ b/src/tests/graphql-aspnet-subscriptions-tests/TestServerExtensions/TestServerSubscriptionHelpers.cs
@@ -15,20 +15,14 @@ namespace GraphQL.Subscriptions.Tests.TestServerExtensions
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Configuration.Mvc;
     using GraphQL.AspNet.Execution.Subscriptions;
-    using GraphQL.AspNet.Interfaces.Configuration;
-    using GraphQL.AspNet.Interfaces.Middleware;
     using GraphQL.AspNet.Interfaces.Subscriptions;
     using GraphQL.AspNet.Interfaces.TypeSystem;
-    using GraphQL.AspNet.Middleware.QueryExecution.Components;
     using GraphQL.AspNet.Middleware.SubcriptionExecution.Components;
-    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.Clients;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Moq;
-    using NUnit.Framework.Internal;
 
     public static class TestServerSubscriptionHelpers
     {

--- a/src/tests/graphql-aspnet-testframework/Clients/MockClientConnection.cs
+++ b/src/tests/graphql-aspnet-testframework/Clients/MockClientConnection.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Framework.Clients
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/tests/graphql-aspnet-testframework/CommonHelpers/InheritedTwoPropertyObject.cs
+++ b/src/tests/graphql-aspnet-testframework/CommonHelpers/InheritedTwoPropertyObject.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Framework.CommonHelpers
+{
+    using System.Diagnostics;
+    using GraphQL.AspNet.Attributes;
+
+    /// <summary>
+    /// A represenstion of some data object with two properties, both declared as graph exposed items.
+    /// </summary>
+    [DebuggerDisplay("InheritedTwoProp: {Property1}")]
+    public class InheritedTwoPropertyObject : TwoPropertyObject
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        /// <value>value.</value>
+        [GraphField]
+        public long Property3 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-testframework/GraphQLProviderRestorePoint.cs
+++ b/src/tests/graphql-aspnet-testframework/GraphQLProviderRestorePoint.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Framework
     using System;
     using GraphQL.AspNet;
     using GraphQL.AspNet.Interfaces.Engine;
-    using GraphQL.AspNet.Schemas;
 
     /// <summary>
     /// A marker to a point in time that, when disposed, will reset the <see cref="GraphQLProviders"/> to the values

--- a/src/tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
+++ b/src/tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
@@ -15,7 +15,6 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
     using System.Text.Json;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Execution.FieldResolution;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Logging;
     using GraphQL.AspNet.Interfaces.TypeSystem;

--- a/src/tests/graphql-aspnet-testframework/TestServer.cs
+++ b/src/tests/graphql-aspnet-testframework/TestServer.cs
@@ -14,7 +14,6 @@ namespace GraphQL.AspNet.Tests.Framework
     using System.Security.Claims;
     using System.Text.Encodings.Web;
     using System.Text.Json;
-    using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Defaults;

--- a/src/tests/graphql-aspnet-tests/Configuration/ConfigurationFieldNamingTests.cs
+++ b/src/tests/graphql-aspnet-tests/Configuration/ConfigurationFieldNamingTests.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Configuration
 {
     using System.Threading.Tasks;
     using GraphQL.AspNet.Configuration.Formatting;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Configuration.ConfigurationTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Controllers/ActionResults/ActuionResultTestData/ActionableController.cs
+++ b/src/tests/graphql-aspnet-tests/Controllers/ActionResults/ActuionResultTestData/ActionableController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Controllers.ActionResults.ActuionResultTestData
     using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class ActionableController : GraphController

--- a/src/tests/graphql-aspnet-tests/Controllers/GraphQueryProcessorTests.cs
+++ b/src/tests/graphql-aspnet-tests/Controllers/GraphQueryProcessorTests.cs
@@ -15,7 +15,6 @@ namespace GraphQL.AspNet.Tests.Controllers
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Web;
     using GraphQL.AspNet.Schemas;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Controllers.GraphQueryControllerData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/BatchFieldExecutorTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/BatchFieldExecutorTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.Execution
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.BatchResolverTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/BatchResolverTestData/BatchController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/BatchResolverTestData/BatchController.cs
@@ -15,7 +15,6 @@ namespace GraphQL.AspNet.Tests.Execution.BatchResolverTestData
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("batch")]

--- a/src/tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
@@ -21,7 +21,6 @@ namespace GraphQL.AspNet.Tests.Execution
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Response;
     using GraphQL.AspNet.Schemas;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayAsEnumerableController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayAsEnumerableController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayAsEnumerableController : GraphIdController
+    {
+        [QueryRoot]
+        public IEnumerable<TwoPropertyObject> RetrieveData()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
@@ -1,0 +1,43 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayOnReturnObjectMethodController : GraphIdController
+    {
+        [QueryRoot]
+        public ArrayObject RetrieveData()
+        {
+            return
+                new ArrayObject()
+                {
+                    PropertyA = "AA",
+                };
+        }
+
+        public class ArrayObject
+        {
+            public string PropertyA { get; set; }
+
+            [GraphField]
+            public TwoPropertyObject[] MoreData()
+            {
+                return new TwoPropertyObject[2]
+                    {
+                        new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                        new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+                    };
+            }
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectMethodController.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections.Generic;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
@@ -1,0 +1,43 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using System.Security.Policy;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayOnReturnObjectPropertyController : GraphIdController
+    {
+        [QueryRoot]
+        public IEnumerable<ArrayObject> RetrieveData()
+        {
+            return new ArrayObject[1]
+            {
+                new ArrayObject()
+                {
+                    PropertyA = "AA",
+                    PropertyB = new TwoPropertyObject[2]
+                    {
+                        new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                        new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+                    },
+                },
+            };
+        }
+
+        public class ArrayObject
+        {
+            public string PropertyA { get; set; }
+
+            public TwoPropertyObject[] PropertyB { get; set; }
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayOnReturnObjectPropertyController.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
     using System.Collections.Generic;
-    using System.Security.Policy;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
     using System.Collections.Generic;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class ArrayScalarController : GraphIdController
     {

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayScalarController.cs
@@ -1,0 +1,25 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayScalarController : GraphIdController
+    {
+        [QueryRoot(typeof(IEnumerable<int>))]
+        public IGraphActionResult RetrieveData()
+        {
+            return this.Ok(new int[] { 1, 3, 5 });
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayThroughArrayDeclarationController : GraphIdController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveData()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughArrayDeclarationController.cs
@@ -9,7 +9,6 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections.Generic;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughGraphActionAsEnumerableController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/ArrayThroughGraphActionAsEnumerableController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayThroughGraphActionAsEnumerableController : GraphIdController
+    {
+        [QueryRoot(typeof(IEnumerable<TwoPropertyObject>))]
+        public IGraphActionResult RetrieveData()
+        {
+            return this.Ok(new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            });
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/BlogProxy.cs
@@ -9,8 +9,6 @@
 
 namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
 {
-    using System.Collections.Generic;
-
     public class BlogProxy : Blog
     {
     }

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/KeyValuePairController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/KeyValuePairController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+
+    public class KeyValuePairController : GraphIdController
+    {
+        [QueryRoot]
+        public IEnumerable<KeyValuePair<string, int>> RetrieveData()
+        {
+            var list = new List<KeyValuePair<string, int>>();
+
+            list.Add(new KeyValuePair<string, int>("key1", 1));
+            list.Add(new KeyValuePair<string, int>("key2", 2));
+
+            return list;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/SimpleExecutionController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/ExecutionPlanTestData/SimpleExecutionController.cs
@@ -17,7 +17,6 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("simple")]

--- a/src/tests/graphql-aspnet-tests/Execution/FragmentExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/FragmentExecutionTests.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Execution
 {
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -898,5 +898,36 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
         }
+
+        [Test]
+        public async Task KeyValuePair_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<KeyValuePairController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () {" +
+                "           key         " +
+                "           value       " +
+                "      }" +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {""key"" : ""key1"", ""value"" : 1 },
+                            {""key"" : ""key2"", ""value"" : 2 }
+                       ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -674,5 +674,229 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
         }
+
+        [Test]
+        public async Task ControllerReturnsAnarrayForAnEnumerableDeclarartion_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayAsEnumerableController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task ControllerReturnsAnArrayForAnArrayThroughGraphActionDeclarartion_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayThroughGraphActionAsEnumerableController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task ControllerReturnsAnArrayForAnArrayDeclaration_YieldsCorrectResult()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayThroughArrayDeclarationController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           property1 " +
+                "           property2 " +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""property1"" : ""1A"",
+                                ""property2"" : 2
+                            },
+                            {
+                                ""property1"" : ""1B"",
+                                ""property2"" : 3
+                            }
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_AsProperty_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayOnReturnObjectPropertyController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           propertyA " +
+                "           propertyB {" +
+                "               property1" +
+                "               property2" +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [
+                            {
+                                ""propertyA"" : ""AA"",
+                                ""propertyB"" : [
+                                    {
+                                        ""property1"" : ""1A"",
+                                        ""property2"" : 2
+                                    },
+                                    {
+                                        ""property1"" : ""1B"",
+                                        ""property2"" : 3
+                                    }
+                                ]
+                            },
+                        ]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_AsObjectMethod_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayOnReturnObjectMethodController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () { " +
+                "           propertyA " +
+                "           moreData() {" +
+                "               property1" +
+                "               property2" +
+                "           }" +
+                "      } " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : {
+                            ""propertyA"" : ""AA"",
+                            ""moreData"" : [
+                                {
+                                    ""property1"" : ""1A"",
+                                    ""property2"" : 2
+                                },
+                                {
+                                    ""property1"" : ""1B"",
+                                    ""property2"" : 3
+                                }
+                            ]
+                         }
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
+
+        [Test]
+        public async Task FlatArray_OfScalard_ResolvesDataCorrectly()
+        {
+            var server = new TestServerBuilder()
+                    .AddGraphType<ArrayScalarController>()
+                    .Build();
+
+            // parentObj has a property called  'child' that is passed as empty on the query
+            // should succeed, all child properties are optional
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query  { " +
+                "      retrieveData () " +
+                "}");
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""retrieveData"" : [1, 3, 5]
+                     }
+                  }";
+
+            var result = await server.RenderResult(builder);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -13,8 +13,6 @@ namespace GraphQL.AspNet.Tests.Execution
     using System.Threading.Tasks;
     using GraphQL.AspNet.Directives.Global;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Schemas.Structural;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.ExecutionPlanTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/InputVariableExecutionTestData/InputValueController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/InputVariableExecutionTestData/InputValueController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Execution.InputVariableExecutionTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoot]

--- a/src/tests/graphql-aspnet-tests/Execution/InputVariableExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/InputVariableExecutionTests.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Execution
 {
     using System.Threading.Tasks;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.InputVariableExecutionTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/InterfaceExecutionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/InterfaceExecutionTests.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Execution
 {
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.InterfaceExtensionTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/IntrospectableObject.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/IntrospectableObject.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Execution.IntrospectionTestData
 {
     using GraphQL.AspNet.Attributes;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class IntrospectableObject

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
@@ -10,18 +10,15 @@
 namespace GraphQL.AspNet.Tests.Execution
 {
     using System.Linq;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.TypeSystem;
     using GraphQL.AspNet.Internal.Introspection.Model;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Execution.IntrospectionTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
-    using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/tests/graphql-aspnet-tests/Extensions/LinqExtensionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Extensions/LinqExtensionTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.Extensions
     using System.Collections.Generic;
     using System.Linq;
     using GraphQL.AspNet.Common.Extensions;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-tests/Extensions/ReflectionExtensionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Extensions/ReflectionExtensionTests.cs
@@ -77,14 +77,22 @@ namespace GraphQL.AspNet.Tests.Extensions
         [TestCase(typeof(IDictionary<int, string>), "IDictionary<int, string>")]
         [TestCase(typeof(IDictionary<int, string>), "IDictionary_int_string_", false, "_")]
         [TestCase(typeof(Task<IDictionary<int, string>>), "Task<IDictionary<int, string>>")]
+        [TestCase(typeof(Task<IDictionary<int, string>>), "Task_IDictionary_int_string__", false, "_")]
         [TestCase(typeof(Task<IDictionary<DateTimeExtensionTests, ReflectionExtensionTests>>), "Task<IDictionary<DateTimeExtensionTests, ReflectionExtensionTests>>")]
-        public void Type_FriendlyName(Type type, string expectedName, bool includeCarrots = true, string delimiter = "")
+        [TestCase(typeof(int[]), "int[]", true)]
+        [TestCase(typeof(int[][]), "int[][]", true)]
+        [TestCase(typeof(int[][]), "int____", false, "_")]
+        [TestCase(typeof(int[]), "int__", false, "_")]
+        public void Type_FriendlyName(Type type, string expectedName, bool useDefaultFriendlyName = true, string delimiter = "")
         {
             // non generic type just returns Type.Name
-            if (includeCarrots)
-                Assert.AreEqual(expectedName, type.FriendlyName());
+            string result;
+            if (useDefaultFriendlyName)
+                result = type.FriendlyName();
             else
-                Assert.AreEqual(expectedName, type.FriendlyName(delimiter));
+                result = type.FriendlyName(delimiter);
+
+            Assert.AreEqual(expectedName, result);
         }
 
         [TestCase(typeof(int), "System.Int32")]

--- a/src/tests/graphql-aspnet-tests/Integration/MusicIndustryTests.cs
+++ b/src/tests/graphql-aspnet-tests/Integration/MusicIndustryTests.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Integration
 {
     using System.IO;
     using System.Threading.Tasks;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Integration.Model;

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithNoSecurityPolicies.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithNoSecurityPolicies.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.GraphValidationTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class ControllerWithNoSecurityPolicies : GraphController
+    {
+        [QueryRoot]
+        public int SomeMethod()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithSecurityPolicies.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTestData/ControllerWithSecurityPolicies.cs
@@ -1,0 +1,25 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.GraphValidationTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using Microsoft.AspNetCore.Authorization;
+
+    public class ControllerWithSecurityPolicies : GraphController
+    {
+        [Authorize]
+        [QueryRoot]
+        public int SomeMethod()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -14,6 +14,7 @@ namespace GraphQL.AspNet.Tests.Internal
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using GraphQL.AspNet.Common.Generics;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.Interfaces;
@@ -50,9 +51,18 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(string[]), true)]
         [TestCase(typeof(DateTime[]), true)]
         [TestCase(typeof(ValidationTestEnum[]), true)]
-        [TestCase(typeof(KeyValuePair<string, string>[]), false)]
-        [TestCase(typeof(KeyValuePair<string, TwoPropertyObject>[]), false)]
-        [TestCase(typeof(KeyValuePair<string, int>[]), false)]
+        [TestCase(typeof(KeyValuePair<string, string>[]), true)]
+        [TestCase(typeof(KeyValuePair<string, TwoPropertyObject>[]), true)]
+        [TestCase(typeof(KeyValuePair<string, int>[]), true)]
+        [TestCase(typeof(IDictionary<string, string>), false)]
+        [TestCase(typeof(IDictionary<string, TwoPropertyObject>), false)]
+        [TestCase(typeof(IDictionary<string, int>), false)]
+        [TestCase(typeof(IReadOnlyDictionary<string, string>), false)]
+        [TestCase(typeof(IReadOnlyDictionary<string, TwoPropertyObject>), false)]
+        [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
+        [TestCase(typeof(Dictionary<string, string>), false)]
+        [TestCase(typeof(Dictionary<string, TwoPropertyObject>), false)]
+        [TestCase(typeof(Dictionary<string, int>), false)]
         public void IsValidListType(Type inputType, bool isValidListType)
         {
             var result = GraphValidation.IsValidListType(inputType);
@@ -73,6 +83,9 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(string), true)]
         [TestCase(typeof(int), true)]
         [TestCase(typeof(DateTime), true)]
+        [TestCase(typeof(KeyValuePair<string, int>), true)]
+        [TestCase(typeof(KeyValuePair<string, int>[]), true)]
+        [TestCase(typeof(List<KeyValuePair<string, int>>), true)]
         [TestCase(typeof(Dictionary<string, int>), false)]
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
@@ -99,6 +112,15 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(TwoPropertyObject[]), "[TwoPropertyObject]", false, null)]
         [TestCase(typeof(int[][]), "[[int!]]", false, null)]
         [TestCase(typeof(string[]), "[string]", false, null)]
+        [TestCase(typeof(KeyValuePair<string, int>), "KeyValuePair_string_int_!", false, null)]
+        [TestCase(typeof(KeyValuePair<string[], int[][]>), "KeyValuePair_string___int_____!", false, null)]
+        [TestCase(typeof(KeyValuePair<string, int[]>), "KeyValuePair_string_int___!", false, null)]
+        [TestCase(typeof(KeyValuePair<string, int[]>[]), "[KeyValuePair_string_int___!]", false, null)]
+        [TestCase(typeof(KeyValuePair<string[][], int[][][]>[]), "[KeyValuePair_string_____int_______!]", false, null)]
+        [TestCase(typeof(KeyValuePair<string[][], int[][][]>[][]), "[[KeyValuePair_string_____int_______!]]", false, null)]
+        [TestCase(typeof(KeyValuePair<string, int>[]), "[KeyValuePair_string_int_!]", false, null)]
+        [TestCase(typeof(List<KeyValuePair<string, int>>), "[KeyValuePair_string_int_!]", false, null)]
+        [TestCase(typeof(List<KeyValuePair<string, int>>), "[KeyValuePair_string_int_]", true, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "[[int!]]", false, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "int!", false, new GTW[] { GTW.IsNotNull })]
         public void GenerateTypeExpression(

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -10,11 +10,9 @@
 namespace GraphQL.AspNet.Tests.Internal
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using GraphQL.AspNet.Common.Generics;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.Interfaces;

--- a/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -10,12 +10,15 @@
 namespace GraphQL.AspNet.Tests.Internal
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.Interfaces;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Internal.GraphValidationTestData;
     using Moq;
     using NUnit.Framework;
     using GTW = GraphQL.AspNet.Schemas.TypeSystem.MetaGraphTypes;
@@ -23,6 +26,12 @@ namespace GraphQL.AspNet.Tests.Internal
     [TestFixture]
     public class GraphValidationTests
     {
+        public enum ValidationTestEnum
+        {
+            Value1,
+            Value2,
+        }
+
         [TestCase(typeof(IEnumerable<int>), true)]
         [TestCase(typeof(ICollection<int>), true)]
         [TestCase(typeof(IList<int>), true)]
@@ -36,6 +45,14 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(Dictionary<string, int>), false)]
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
+        [TestCase(typeof(TwoPropertyObject[]), true)]
+        [TestCase(typeof(int[]), true)]
+        [TestCase(typeof(string[]), true)]
+        [TestCase(typeof(DateTime[]), true)]
+        [TestCase(typeof(ValidationTestEnum[]), true)]
+        [TestCase(typeof(KeyValuePair<string, string>[]), false)]
+        [TestCase(typeof(KeyValuePair<string, TwoPropertyObject>[]), false)]
+        [TestCase(typeof(KeyValuePair<string, int>[]), false)]
         public void IsValidListType(Type inputType, bool isValidListType)
         {
             var result = GraphValidation.IsValidListType(inputType);
@@ -49,12 +66,17 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(List<string>), true)]
         [TestCase(typeof(List<DateTime>), true)]
         [TestCase(typeof(List<TwoPropertyObject>), true)]
+        [TestCase(typeof(TwoPropertyObject[]), true)]
+        [TestCase(typeof(int[]), true)]
+        [TestCase(typeof(string[]), true)]
+        [TestCase(typeof(DateTime[]), true)]
         [TestCase(typeof(string), true)]
         [TestCase(typeof(int), true)]
         [TestCase(typeof(DateTime), true)]
         [TestCase(typeof(Dictionary<string, int>), false)]
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
+        [TestCase(typeof(object), false)]
         public void IsValidGraphType(Type inputType, bool isValidType)
         {
             var result = GraphValidation.IsValidGraphType(inputType);
@@ -71,6 +93,12 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(int), "int!", false, null)]
         [TestCase(typeof(int), "int", true, null)]
         [TestCase(typeof(IEnumerable<int>), "[int!]", false, null)]
+        [TestCase(typeof(int[]), "[int!]", false, null)]
+        [TestCase(typeof(IEnumerable<TwoPropertyObject>), "[TwoPropertyObject]", false, null)]
+        [TestCase(typeof(TwoPropertyObject[]), "[TwoPropertyObject]", true, null)]
+        [TestCase(typeof(TwoPropertyObject[]), "[TwoPropertyObject]", false, null)]
+        [TestCase(typeof(int[][]), "[[int!]]", false, null)]
+        [TestCase(typeof(string[]), "[string]", false, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "[[int!]]", false, null)]
         [TestCase(typeof(IEnumerable<IEnumerable<int>>), "int!", false, new GTW[] { GTW.IsNotNull })]
         public void GenerateTypeExpression(
@@ -85,6 +113,57 @@ namespace GraphQL.AspNet.Tests.Internal
 
             var typeExpression = GraphValidation.GenerateTypeExpression(type, mock.Object);
             Assert.AreEqual(expectedExpression, typeExpression.ToString());
+        }
+
+        [TestCase(typeof(int), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int>), typeof(Task<int>), true, false, true)]
+        [TestCase(typeof(int?), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<List<int?>>), typeof(int), true, true, true)]
+        [TestCase(typeof(List<int>), typeof(int), true, true, true)]
+        [TestCase(typeof(int?), typeof(int?), true, true, false)]
+        [TestCase(typeof(int[]), typeof(int), true, true, true)]
+        [TestCase(typeof(int[]), typeof(int[]), false, true, true)]
+        [TestCase(typeof(string[]), typeof(string), true, true, true)]
+        [TestCase(typeof(Task<int[]>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?[]>), typeof(int), true, true, true)]
+        [TestCase(typeof(Task<int?[]>), typeof(int?), true, true, false)]
+        [TestCase(typeof(Task<int?[]>), typeof(Task<int?[]>), true, false, true)]
+        public void EliminateWrappersFromCoreType(
+            Type typeToTest,
+            Type expectedCoreType,
+            bool removeEnumerables,
+            bool removeTask,
+            bool removeNullableT)
+        {
+            var result = GraphValidation.EliminateWrappersFromCoreType(typeToTest, removeEnumerables, removeTask, removeNullableT);
+            Assert.AreEqual(expectedCoreType, result);
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_NullAttributeProvider_YieldsNoPolicies()
+        {
+            var policies = GraphValidation.RetrieveSecurityPolicies(null);
+            Assert.AreEqual(0, policies.Count());
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_MethodWithNoSecurityPolicies_ReturnsEmptyEnumerable()
+        {
+            var info = typeof(ControllerWithNoSecurityPolicies).GetMethod(nameof(ControllerWithNoSecurityPolicies.SomeMethod));
+
+            var policies = GraphValidation.RetrieveSecurityPolicies(info);
+            Assert.AreEqual(0, policies.Count());
+        }
+
+        [Test]
+        public void RetrieveSecurityPolicies_MethodWithSecurityPolicies_ReturnsOneItem()
+        {
+            var info = typeof(ControllerWithSecurityPolicies).GetMethod(nameof(ControllerWithSecurityPolicies.SomeMethod));
+
+            var policies = GraphValidation.RetrieveSecurityPolicies(info);
+            Assert.AreEqual(1, policies.Count());
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/ObjectMethodResolverTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/ObjectMethodResolverTests.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Internal
     using System;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Internal.Resolvers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.ValueResolversTestData;

--- a/src/tests/graphql-aspnet-tests/Internal/ObjectPropertyResolverTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/ObjectPropertyResolverTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.Internal
     using System.Threading.Tasks;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.Resolvers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Extensions.DiExtensionTestData;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/ActionResultReturnTypeController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/ActionResultReturnTypeController.cs
@@ -14,7 +14,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ActionTestData
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("path0")]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/ContainerController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/ContainerController.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ActionTestData
     using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("path0")]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/InterfaceReturnTypeController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/InterfaceReturnTypeController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ActionTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class InterfaceReturnTypeController : GraphController

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/OneMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/OneMethodController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ActionTestData
     using System.ComponentModel;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("path0")]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/UnionTestController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ActionTestData/UnionTestController.cs
@@ -14,7 +14,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ActionTestData
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("unionTest")]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ArrayReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ArrayReturnController.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class ArrayReturnController : GraphController
+    {
+        [QueryRoot]
+        public string[] RetrieveData()
+        {
+            return new string[0];
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/OneMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/OneMethodController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class OneMethodController : GraphController

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodClashController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodClashController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     /// <summary>

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodNoClashController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodNoClashController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     /// <summary>

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodsDifferentRootsController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/TwoMethodsDifferentRootsController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     /// <summary>

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ExtensionMethodTestData/SimpleExtensionMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ExtensionMethodTestData/SimpleExtensionMethodController.cs
@@ -14,7 +14,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ExtensionMethodTestData
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class SimpleExtensionMethodController : GraphController

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphActionTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphActionTemplateTests.cs
@@ -18,7 +18,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Internal.TypeTemplates;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ActionTestData;
     using Moq;

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
@@ -15,9 +15,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData;
-    using GraphQL.AspNet.Common.Extensions;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphControllerTemplateTests.cs
@@ -12,8 +12,12 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using System.Linq;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using NUnit.Framework;
 
     [TestFixture]
@@ -48,6 +52,23 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[mutation]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[query]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
             Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/TwoPropertyObject/Property3"));
+        }
+
+        [Test]
+        public void Parse_ReturnArrayOnAction_ParsesCorrectly()
+        {
+            var expectedTypeExpression = new GraphTypeExpression(
+                "String",
+                MetaGraphTypes.IsList);
+
+            var template = GraphQLProviders.TemplateProvider.ParseType<ArrayReturnController>() as GraphControllerTemplate;
+            Assert.IsNotNull(template);
+
+            Assert.AreEqual(1, template.Actions.Count());
+
+            var action = template.Actions.ElementAt(0);
+            Assert.AreEqual(typeof(string[]), action.DeclaredReturnType);
+            Assert.AreEqual(expectedTypeExpression, action.TypeExpression);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
@@ -12,11 +12,13 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.MethodTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
 
@@ -164,6 +166,25 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
         {
             var template = this.CreateMethodTemplate<MethodClass>(nameof(MethodClass.TaskOfListOfObjectReturnType));
             Assert.AreEqual(typeof(TwoPropertyObject), template.ObjectType);
+        }
+
+
+        [Test]
+        public void Parse_ArrayFromMethod_YieldsTemplate()
+        {
+            var obj = new Mock<IObjectGraphTypeTemplate>();
+            obj.Setup(x => x.Route).Returns(new GraphFieldPath("[type]/Item0"));
+            obj.Setup(x => x.InternalFullName).Returns("Item0");
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            var parent = obj.Object;
+            var template = this.CreateMethodTemplate<ArrayMethodObject>(nameof(ArrayMethodObject.RetrieveData));
+
+            Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
+            Assert.AreEqual(typeof(TwoPropertyObject[]), template.DeclaredReturnType);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectMethodTemplateTests.cs
@@ -15,7 +15,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.MethodTestData;
     using GraphQL.AspNet.Common.Extensions;
@@ -167,7 +166,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             var template = this.CreateMethodTemplate<MethodClass>(nameof(MethodClass.TaskOfListOfObjectReturnType));
             Assert.AreEqual(typeof(TwoPropertyObject), template.ObjectType);
         }
-
 
         [Test]
         public void Parse_ArrayFromMethod_YieldsTemplate()

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
@@ -16,7 +16,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Exceptions;
-    using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.TypeTemplates;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.TypeSystem;

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphObjectTemplateTests.cs
@@ -15,8 +15,12 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests;
+    using GraphQL.AspNet.Common.Extensions;
     using NUnit.Framework;
+    using GraphQL.AspNet.Schemas.TypeSystem;
 
     [TestFixture]
     public class GraphObjectTemplateTests
@@ -172,6 +176,28 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             // should have the declared method, the undeclared but valid method, the decalred property
             // the invalid undeclared method should be dropped silently
             Assert.AreEqual(3, template.FieldTemplates.Count);
+        }
+
+        [Test]
+        public void Parse_ArrayProperty_ExtractsListOfCoreType()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(TypeWithArrayProperty));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            // should have the declared method, the undeclared but valid method, the decalred property
+            // the invalid undeclared method should be dropped silently
+            Assert.AreEqual(1, template.FieldTemplates.Count);
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            Assert.AreEqual(1, template.FieldTemplates.Count());
+            var fieldTemplate = template.FieldTemplates.ElementAt(0).Value;
+            Assert.AreEqual(typeof(TwoPropertyObject[]), fieldTemplate.DeclaredReturnType);
+            Assert.AreEqual(typeof(TwoPropertyObject), fieldTemplate.ObjectType);
+            Assert.AreEqual(expectedTypeExpression, fieldTemplate.TypeExpression);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
@@ -9,20 +9,20 @@
 
 namespace GraphQL.AspNet.Tests.Internal.Templating
 {
+    using System.Collections.Generic;
     using System.Linq;
+    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.TypeTemplates;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
-    using GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests;
     using GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData;
-    using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
-    using System.Collections.Generic;
 
     [TestFixture]
     public class GraphPropertyTemplateTests
@@ -196,7 +196,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             obj.Setup(x => x.InternalFullName).Returns("Item0");
 
             var expectedTypeExpression = new GraphTypeExpression(
-                typeof(KeyValuePair<string, string>).FriendlyName("_"),
+                typeof(KeyValuePair<string, string>).FriendlyGraphTypeName(),
                 MetaGraphTypes.IsList,
                 MetaGraphTypes.IsNotNull); // structs can't be null
 

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
@@ -22,6 +22,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
+    using System.Collections.Generic;
 
     [TestFixture]
     public class GraphPropertyTemplateTests
@@ -185,6 +186,29 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
 
             Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
             Assert.AreEqual(typeof(TwoPropertyObject[]), template.DeclaredReturnType);
+        }
+
+        [Test]
+        public void Parse_BasicObject_PropertyReturnsArrayOfKeyValuePair_YieldsTemplate()
+        {
+            var obj = new Mock<IObjectGraphTypeTemplate>();
+            obj.Setup(x => x.Route).Returns(new GraphFieldPath("[type]/Item0"));
+            obj.Setup(x => x.InternalFullName).Returns("Item0");
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(KeyValuePair<string, string>).FriendlyName("_"),
+                MetaGraphTypes.IsList,
+                MetaGraphTypes.IsNotNull); // structs can't be null
+
+            var parent = obj.Object;
+            var propInfo = typeof(ArrayKeyValuePairObject).GetProperty(nameof(ArrayKeyValuePairObject.PropertyA));
+
+            var template = new PropertyGraphFieldTemplate(parent, propInfo, TypeKind.OBJECT);
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
+            Assert.AreEqual(typeof(KeyValuePair<string, string>[]), template.DeclaredReturnType);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphPropertyTemplateTests.cs
@@ -13,9 +13,13 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Internal.TypeTemplates;
+    using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests;
     using GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData;
+    using GraphQL.AspNet.Common.Extensions;
     using Moq;
     using NUnit.Framework;
 
@@ -159,6 +163,28 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             {
                 template.ValidateOrThrow();
             });
+        }
+
+        [Test]
+        public void Parse_BasicObject_PropertyReturnsArray_YieldsTemplate()
+        {
+            var obj = new Mock<IObjectGraphTypeTemplate>();
+            obj.Setup(x => x.Route).Returns(new GraphFieldPath("[type]/Item0"));
+            obj.Setup(x => x.InternalFullName).Returns("Item0");
+
+            var expectedTypeExpression = new GraphTypeExpression(
+                typeof(TwoPropertyObject).FriendlyName(),
+                MetaGraphTypes.IsList);
+
+            var parent = obj.Object;
+            var propInfo = typeof(ArrayPropertyObject).GetProperty(nameof(ArrayPropertyObject.PropertyA));
+
+            var template = new PropertyGraphFieldTemplate(parent, propInfo, TypeKind.OBJECT);
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(expectedTypeExpression, template.TypeExpression);
+            Assert.AreEqual(typeof(TwoPropertyObject[]), template.DeclaredReturnType);
         }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphTypeExtensionMethodTemplateTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphTypeExtensionMethodTemplateTests.cs
@@ -17,7 +17,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Internal.TypeTemplates;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ExtensionMethodTestData;
     using Moq;

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/GraphTypeMakerTests.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/GraphTypeMakerTests.cs
@@ -22,7 +22,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Internal.Templating.ActionTestData;

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/ArrayMethodObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/ArrayMethodObject.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.MethodTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayMethodObject
+    {
+        [GraphField]
+        public TwoPropertyObject[] RetrieveData()
+        {
+            return null;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/MethodClass.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/MethodTestData/MethodClass.cs
@@ -14,7 +14,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.MethodTestData
     using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class MethodClass
@@ -125,7 +124,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.MethodTestData
         [GraphField]
         public Task<List<TwoPropertyObject>> TaskOfListOfObjectReturnType()
         {
-            return null;
+            return Task.FromResult(null as List<TwoPropertyObject>);
         }
 
         [GraphField]

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeCreationItem.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeCreationItem.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
 {
     using GraphQL.AspNet.Attributes;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class TypeCreationItem

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeWithArrayProperty.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/TypeWithArrayProperty.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class TypeWithArrayProperty
+    {
+        public TwoPropertyObject[] PropertyA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayKeyValuePairObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayKeyValuePairObject.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayKeyValuePairObject
+    {
+        public KeyValuePair<string, string>[] PropertyA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayKeyValuePairObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayKeyValuePairObject.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData
 {
     using System.Collections.Generic;
-    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class ArrayKeyValuePairObject
     {

--- a/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayPropertyObject.cs
+++ b/src/tests/graphql-aspnet-tests/Internal/Templating/PropertyTestData/ArrayPropertyObject.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.PropertyTestData
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayPropertyObject
+    {
+        public TwoPropertyObject[] PropertyA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Logging/EndToEndTests.cs
+++ b/src/tests/graphql-aspnet-tests/Logging/EndToEndTests.cs
@@ -9,10 +9,8 @@
 
 namespace GraphQL.AspNet.Tests.Logging
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.Caching;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Logging;
     using GraphQL.AspNet.Schemas;

--- a/src/tests/graphql-aspnet-tests/Logging/GeneralEventLogEntryPropertyChecks.cs
+++ b/src/tests/graphql-aspnet-tests/Logging/GeneralEventLogEntryPropertyChecks.cs
@@ -22,7 +22,6 @@ namespace GraphQL.AspNet.Tests.Logging
     using GraphQL.AspNet.Logging.ExecutionEvents;
     using GraphQL.AspNet.Logging.ExecutionEvents.PropertyItems;
     using GraphQL.AspNet.Middleware.FieldExecution;
-    using GraphQL.AspNet.Middleware.QueryExecution;
     using GraphQL.AspNet.Response;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Security;

--- a/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineComponentTests.cs
+++ b/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineComponentTests.cs
@@ -10,18 +10,13 @@
 namespace GraphQL.AspNet.Tests.Middleware
 {
     using System;
-    using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Execution;
-    using GraphQL.AspNet.Middleware;
     using GraphQL.AspNet.Middleware.QueryExecution;
     using GraphQL.AspNet.Middleware.QueryExecution.Components;
-    using GraphQL.AspNet.Tests.Framework;
-    using GraphQL.AspNet.Tests.Framework.PipelineContextBuilders;
-    using GraphQL.AspNet.Tests.Middleware.QueryPipelineIntegrationTestData;
     using Moq;
     using NUnit.Framework;
 

--- a/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTestData/SimpleExecutionController.cs
+++ b/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTestData/SimpleExecutionController.cs
@@ -17,7 +17,6 @@ namespace GraphQL.AspNet.Tests.Middleware.QueryPipelineIntegrationTestData
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("simple")]

--- a/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Middleware/QueryPipelineIntegrationTests.cs
@@ -9,27 +9,18 @@
 
 namespace GraphQL.AspNet.Tests.Middleware
 {
-    using System;
     using System.Runtime.Caching;
-    using System.Security.Policy;
-    using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Defaults;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Engine;
-    using GraphQL.AspNet.Interfaces.Middleware;
-    using GraphQL.AspNet.Middleware.FieldExecution;
-    using GraphQL.AspNet.Middleware.FieldExecution.Components;
     using GraphQL.AspNet.Middleware.QueryExecution;
     using GraphQL.AspNet.Parsing;
     using GraphQL.AspNet.Schemas;
-    using GraphQL.AspNet.Schemas.Structural;
     using GraphQL.AspNet.Tests.Framework;
-    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Middleware.QueryPipelineIntegrationTestData;
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/tests/graphql-aspnet-tests/PlanGeneration/ArgumentGeneratorTestData/InputController.cs
+++ b/src/tests/graphql-aspnet-tests/PlanGeneration/ArgumentGeneratorTestData/InputController.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.PlanGeneration.ArgumentGeneratorTestData
     using System.Linq;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class InputController : GraphController

--- a/src/tests/graphql-aspnet-tests/PlanGeneration/ArgumentGeneratorTests.cs
+++ b/src/tests/graphql-aspnet-tests/PlanGeneration/ArgumentGeneratorTests.cs
@@ -11,14 +11,11 @@ namespace GraphQL.AspNet.Tests.PlanGeneration
 {
     using System;
     using System.Collections.Generic;
-    using System.Net.Mail;
     using GraphQL.AspNet.Defaults;
-    using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Interfaces.TypeSystem;
     using GraphQL.AspNet.Parsing;
     using GraphQL.AspNet.PlanGeneration.InputArguments;
     using GraphQL.AspNet.Schemas;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.PlanGeneration.ArgumentGeneratorTestData;

--- a/src/tests/graphql-aspnet-tests/PlanGeneration/ExecutionPlanGenerationTests.cs
+++ b/src/tests/graphql-aspnet-tests/PlanGeneration/ExecutionPlanGenerationTests.cs
@@ -17,7 +17,6 @@ namespace GraphQL.AspNet.Tests.PlanGeneration
     using GraphQL.AspNet.Parsing;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.Schemas.TypeSystem;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.PlanGeneration.PlanGenerationTestData;

--- a/src/tests/graphql-aspnet-tests/PlanGeneration/PlanGenerationTestData/SimplePlanGenerationController.cs
+++ b/src/tests/graphql-aspnet-tests/PlanGeneration/PlanGenerationTestData/SimplePlanGenerationController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.PlanGeneration.PlanGenerationTestData
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Interfaces.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("simple")]

--- a/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
@@ -731,5 +731,22 @@ namespace GraphQL.AspNet.Tests.Schemas
             Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
             Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
         }
+
+        [Test]
+        public void EnsureGraphType_WhenTypeIsAGeneric_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<KeyValuePairObject>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(KeyValuePairObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(KeyValuePair<string, int>)));
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
@@ -634,5 +634,102 @@ namespace GraphQL.AspNet.Tests.Schemas
                 manager.EnsureGraphType<ControllerWithRootName2>();
             });
         }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerReturnTypeIsGraphTypeIsAFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayReturnController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerReturnTypeDeclarationIsGraphTypeIsAFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayReturnDeclarationController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerInputTypeIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayObjectInputController>();
+
+            Assert.AreEqual(4, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.INPUT_OBJECT));
+
+            Assert.IsFalse(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.OBJECT));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenControllerInputTypeIsFlatArrayAndReturnsFlatArray_ArrayIsAddedAsInputAndReturnType()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayInputAndReturnController>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.INPUT_OBJECT));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenPropertyIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayPropertyObject>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(ArrayPropertyObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
+
+        [Test]
+        public void EnsureGraphType_WhenMethodReturnIsFlatArray_IsAddedCorrectly()
+        {
+            var schema = new GraphSchema() as ISchema;
+            schema.SetNoAlterationConfiguration();
+
+            var manager = new GraphSchemaManager(schema);
+            manager.EnsureGraphType<ArrayMethodObject>();
+
+            Assert.AreEqual(5, schema.KnownTypes.Count); // added types + query
+
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(ArrayMethodObject)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(string)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(int)));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject)));
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayInputAndReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayInputAndReturnController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayInputAndReturnController : GraphController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveArray(TwoPropertyObject[] items)
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayMethodObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayMethodObject.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayMethodObject
+    {
+        [GraphField]
+        public TwoPropertyObject[] SubData()
+        {
+            return null;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayObjectInputController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayObjectInputController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayObjectInputController : GraphController
+    {
+        [QueryRoot]
+        public string ArrayIn(TwoPropertyObject[] inputObjects)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayPropertyObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayPropertyObject.cs
@@ -1,0 +1,20 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayPropertyObject
+    {
+        public string Prop1 { get; set; }
+
+        public TwoPropertyObject[] Prop2 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnController.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayReturnController : GraphController
+    {
+        [QueryRoot]
+        public TwoPropertyObject[] RetrieveArray()
+        {
+            return new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            };
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnDeclarationController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/ArrayReturnDeclarationController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Interfaces.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ArrayReturnDeclarationController : GraphController
+    {
+        [QueryRoot(typeof(TwoPropertyObject[]))]
+        public IGraphActionResult RetrieveArray()
+        {
+            return this.Ok(new TwoPropertyObject[2]
+            {
+                new TwoPropertyObject() { Property1 = "1A", Property2 = 2, },
+                new TwoPropertyObject() { Property1 = "1B", Property2 = 3, },
+            });
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/DictionaryMethodObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/DictionaryMethodObject.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
     using System.Collections.Generic;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class DictionaryMethodObject : GraphController

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/KeyValuePairObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/KeyValuePairObject.cs
@@ -10,8 +10,6 @@
 namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
 {
     using System.Collections.Generic;
-    using GraphQL.AspNet.Attributes;
-    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class KeyValuePairObject
     {

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/KeyValuePairObject.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/KeyValuePairObject.cs
@@ -1,0 +1,20 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class KeyValuePairObject
+    {
+        public KeyValuePair<string, int> Prop1 { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/NestedQueryMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/NestedQueryMethodController.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
     using System;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     [GraphRoute("path0")]

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/SimpleMethodController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/SimpleMethodController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     /// <summary>

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/TypeExtensionController.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTestData/TypeExtensionController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
     public class TypeExtensionController : GraphController

--- a/src/tests/graphql-aspnet-tests/Schemas/SchemaTypeCollectionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/SchemaTypeCollectionTests.cs
@@ -18,12 +18,10 @@ namespace GraphQL.AspNet.Tests.Schemas
     using GraphQL.AspNet.Internal.Interfaces;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using GraphQL.AspNet.Schemas.TypeSystem.TypeCollections;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Schemas.GraphTypeCollectionTestData;
     using GraphQL.AspNet.Tests.Schemas.SchemaTestData;
-    using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.Serialization;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/tests/graphql-aspnet-tests/Security/PerFieldAuthorizationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Security/PerFieldAuthorizationTests.cs
@@ -13,7 +13,6 @@ namespace GraphQL.AspNet.Tests.Security
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Security;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using GraphQL.AspNet.Tests.Security.SecurtyGroupData;

--- a/src/tests/graphql-aspnet-tests/Security/PerRequestAuthorizationTests.cs
+++ b/src/tests/graphql-aspnet-tests/Security/PerRequestAuthorizationTests.cs
@@ -12,7 +12,6 @@ namespace GraphQL.AspNet.Tests.Security
     using System;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Security;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;

--- a/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/PerFieldCounterController.cs
+++ b/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/PerFieldCounterController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Security.SecurtyGroupData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using Microsoft.AspNetCore.Authorization;
 

--- a/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/PerRequestCounterController.cs
+++ b/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/PerRequestCounterController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Security.SecurtyGroupData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using Microsoft.AspNetCore.Authorization;
 

--- a/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/SecuredController.cs
+++ b/src/tests/graphql-aspnet-tests/Security/SecurtyGroupData/SecuredController.cs
@@ -11,7 +11,6 @@ namespace GraphQL.AspNet.Tests.Security.SecurtyGroupData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.CommonHelpers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
     using Microsoft.AspNetCore.Authorization;
 


### PR DESCRIPTION
* Fixed a bug where flat arrays (i.e. `int[]`) were not considered valid list types. 
  *  Any flat arrays of `T[]` can be returned for any graph type declared as `IEnumerable<T>`
* Added the ability for non-scalar value types to be used as OBJECT graph types
  * This includes built in types such as `KeyValuePair<T, K>` 
  * **EXCEPTION** Types implementing `IReadOnlyDictionary<T, K>`, `IDictionary<T,K>`  are not valid graph types in any scenario even though they may implement `IEnumerable<KeyValuePair<T, K>>`
  * **EXCEPTION**: Any structs already registered to the global scalar collection are also rejected


Note: Non-scalar Value Types CANNOT be used as INPUT object types


```csharp
public class KVPController : GraphController
{
   // Invalid as INPUT_OBJECT type
   [QueryRoot]
   public IEnumerable<string> GetData(KeyValuePair<string, int> inputValue) {}


   // Valid as OBJECT type
   [QueryRoot]
   public IEnumerable<KeyValuePair<string, int>> GetOtherData( {}


}
```
_Example of using a value type (`KeyValuePair<string, int>) correctly and incorrectly._


TO DO: More Unit tests for value type scenarios