### PR TITLE
Bug Fix with Default Auth Scheme

### DIFF
--- a/src/tests/graphql-aspnet-tests/Middleware/FieldAuthenticationMiddlewareTests.cs
+++ b/src/tests/graphql-aspnet-tests/Middleware/FieldAuthenticationMiddlewareTests.cs
@@ -8,6 +8,7 @@
 // *************************************************************
 namespace GraphQL.AspNet.Tests.Middleware
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -154,7 +155,7 @@ namespace GraphQL.AspNet.Tests.Middleware
             contextBuilder.AddSecurityContext(null);
             var queryContext = contextBuilder.Build();
 
-            var testGroup = FieldSecurityGroup.FromAttributeCollection(typeof(AllowAnonymousOnAuthorize));
+            var testGroup = FieldSecurityGroup.FromAttributeCollection(typeof(NoRequriedSchemeOnAuthorize));
 
             var field = new Mock<IGraphField>();
             field.Setup(x => x.SecurityGroups).Returns(testGroup.AsEnumerable<FieldSecurityGroup>());
@@ -270,7 +271,7 @@ namespace GraphQL.AspNet.Tests.Middleware
         }
 
         [Test]
-        public async Task WhenNestedGroupsEncountered_AndUserContextMatches_Authorized()
+        public async Task WhenNestedGroupsEncountered_AndUserContextMatches_IsAuthorized()
         {
             var builder = new TestServerBuilder();
             builder.UserContext.Authenticate("testScheme1");
@@ -301,6 +302,47 @@ namespace GraphQL.AspNet.Tests.Middleware
             Assert.IsNotNull(securityContext.AuthenticatedUser);
             Assert.AreEqual(expectedUser, securityContext.AuthenticatedUser);
             Assert.IsNull(securityContext.Result);
+        }
+
+        [Test]
+        public async Task WhenFailsDefaultScheme_AndNoOtherSchemes_FailsToAuthenticate()
+        {
+            var builder = new TestServerBuilder();
+            var server = builder.Build();
+
+            var defaultResult = new Mock<IAuthenticationResult>();
+            defaultResult.Setup(x => x.Suceeded).Returns(false);
+
+            var userSecurityContext = new Mock<IUserSecurityContext>();
+            userSecurityContext.Setup(x => x.Authenticate(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(defaultResult.Object);
+
+            userSecurityContext.Setup(x => x.Authenticate(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("unknown scheme"));
+
+            var contextBuilder = server.CreateQueryContextBuilder();
+            contextBuilder.AddSecurityContext(userSecurityContext.Object);
+            var queryContext = contextBuilder.Build();
+
+            // has "default" required
+            var testGroup = FieldSecurityGroup.FromAttributeCollection(typeof(NoRequriedSchemeOnAuthorize));
+
+            var field = new Mock<IGraphField>();
+            field.Setup(x => x.SecurityGroups).Returns(new List<FieldSecurityGroup>() { testGroup });
+            field.Setup(x => x.Route).Returns(new GraphFieldPath(AspNet.Execution.GraphCollection.Types, "segment1"));
+
+            var fieldSecurityRequest = new Mock<IGraphFieldSecurityRequest>();
+            fieldSecurityRequest.Setup(x => x.Field)
+                .Returns(field.Object);
+
+            var securityContext = new GraphFieldSecurityContext(queryContext, fieldSecurityRequest.Object);
+
+            var middleware = new FieldAuthenticationMiddleware();
+            await middleware.InvokeAsync(securityContext, this.EmptyNextDelegate);
+
+            Assert.IsNull(securityContext.AuthenticatedUser);
+            Assert.IsNotNull(securityContext.Result);
+            Assert.AreEqual(FieldSecurityChallengeStatus.Unauthenticated, securityContext.Result.Status);
         }
     }
 }


### PR DESCRIPTION
* Fixed a bug where by if the default auth scheme fails, it would be attempted a second time but with an incorrect scheme moniker causing a "scheme not registered" exception to be thrown.
* Fixed a bug where `AllowAnonymous` was not properly respected when it appeared on all nested security groups of a given graph field.