### PR TITLE
Added support for data type short as scalar type

### DIFF
--- a/src/graphql-aspnet/Constants.cs
+++ b/src/graphql-aspnet/Constants.cs
@@ -174,6 +174,7 @@ namespace GraphQL.AspNet
             public const string GUID = "Guid";
             public const string URI = "Uri";
             public const string ID = "ID";
+            public const string SHORT = "Short";
 
 #if NET6_0_OR_GREATER
             public const string DATEONLY = "DateOnly";

--- a/src/graphql-aspnet/Defaults/DefaultScalarTypeProvider.cs
+++ b/src/graphql-aspnet/Defaults/DefaultScalarTypeProvider.cs
@@ -58,6 +58,7 @@ namespace GraphQL.AspNet.Defaults
             this.RegisterScalar(typeof(GuidScalarType));
             this.RegisterScalar(typeof(UriScalarType));
             this.RegisterScalar(typeof(GraphIdScalarType));
+            this.RegisterScalar(typeof(ShortScalarType));
 
 #if NET6_0_OR_GREATER
             this.RegisterScalar(typeof(DateOnlyScalarType));

--- a/src/graphql-aspnet/Response/BaseResponseWriter.cs
+++ b/src/graphql-aspnet/Response/BaseResponseWriter.cs
@@ -209,6 +209,10 @@ namespace GraphQL.AspNet.Response
                     this.WritePreEncodedStringValue(writer, dto.ToRfc3339String());
                     break;
 
+                case short sh:
+                    writer.WriteNumberValue(sh);
+                    break;
+
 #if NET6_0_OR_GREATER
                 case DateOnly dateOnly:
                     this.WritePreEncodedStringValue(writer, dateOnly.ToRfc3339String());

--- a/src/graphql-aspnet/Schemas/TypeSystem/Scalars/ShortScalarType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Scalars/ShortScalarType.cs
@@ -1,0 +1,48 @@
+﻿namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Parsing.SyntaxNodes;
+
+    /// <summary>
+    /// A graph type representing a short.
+    /// </summary>
+    [DebuggerDisplay("SCALAR: {Name}")]
+    public sealed class ShortScalarType : BaseScalarType
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShortScalarType"/> class.
+        /// </summary>
+        public ShortScalarType()
+            : base(Constants.ScalarNames.SHORT, typeof(short))
+        {
+            this.Description = $"A short. (Min: {short.MinValue}, Max: {short.MaxValue})";
+            this.OtherKnownTypes = new TypeCollection(typeof(short?));
+        }
+
+        /// <inheritdoc />
+        public override TypeCollection OtherKnownTypes { get; }
+
+        /// <inheritdoc />
+        public override ScalarValueType ValueType => ScalarValueType.Number;
+
+        /// <inheritdoc />
+        public override object Resolve(ReadOnlySpan<char> data)
+        {
+            if (short.TryParse(data.ToString(), out var i))
+                return i;
+
+            throw new UnresolvedValueException(data);
+        }
+
+        /// <inheritdoc />
+        public override object Serialize(object item)
+        {
+            return item;
+        }
+    }
+}

--- a/src/graphql-aspnet/Schemas/TypeSystem/Scalars/ShortScalarType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Scalars/ShortScalarType.cs
@@ -1,9 +1,16 @@
-﻿namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Schemas.TypeSystem.Scalars
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Text;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Parsing.SyntaxNodes;

--- a/src/tests/graphql-aspnet-tests/Schemas/ScalarTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/ScalarTests.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Tests.Schemas
 {
     using System;
-    using System.Reflection;
     using GraphQL.AspNet.Common.Generics;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.TypeSystem;
@@ -95,6 +94,11 @@ namespace GraphQL.AspNet.Tests.Schemas
             new object[] { typeof(UriScalarType), "-1", null, true },
             new object[] { typeof(UriScalarType), "\"abc\"", new Uri("abc", UriKind.RelativeOrAbsolute), false },
 
+            new object[] { typeof(ShortScalarType), "1", 1, false },
+            new object[] { typeof(ShortScalarType), "-1", -1, false },
+            new object[] { typeof(ShortScalarType), "\"1\"", null, true },
+            new object[] { typeof(ShortScalarType), "\"abc\"", null, true },
+
 #if NET6_0_OR_GREATER
             new object[] { typeof(DateOnlyScalarType), "\"2021-11-12\"", new DateOnly(2021, 11, 12), false },
             new object[] { typeof(DateOnlyScalarType), "\"2021-10-21T11:12:13+00:00\"", new DateOnly(2021, 10, 21), false },
@@ -159,6 +163,7 @@ namespace GraphQL.AspNet.Tests.Schemas
 
             new object[] { typeof(UriScalarType), new Uri("http://fakewebsite.com", UriKind.RelativeOrAbsolute), "http://fakewebsite.com/" },
             new object[] { typeof(UriScalarType), null, null },
+            new object[] { typeof(ShortScalarType), 1, 1, },
 
 #if NET6_0_OR_GREATER
             new object[] { typeof(DateOnlyScalarType), new DateOnly(2021, 10, 11), new DateOnly(2021, 10, 11) },


### PR DESCRIPTION
Hey!

First of all I want to thank you for the repository. I really like to work with GraphQL ASP.NET.

Resource: https://graphql-aspnet.github.io/docs/types/scalars

## Changes Made

I added the data type short  as a scalar called  ``ShortScalarType`` to the  ``DefaultScalarTypeProvider``.
With this change, shorts can hopefully be used as properties in models/entities and are recognized within the schema.
With changes in ``BaseResponseWriter`` the short should be send back as a leaf value in the response.