### PR TITLE
Reverted CI pipeline vm to ubuntu-18.04

### DIFF
--- a/build/deployment.yml
+++ b/build/deployment.yml
@@ -17,7 +17,7 @@
 # container to be picked up by a release pipeline when triggered by a team member.
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-18.04
 
 steps:
   ## Install .NET Core 3.1

--- a/build/pull-request.yml
+++ b/build/pull-request.yml
@@ -11,7 +11,7 @@
 # executed against any branch with an open PR against any of the protected branches.
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-18.04
 
 steps:
   ## Install dotnetcore 3.1


### PR DESCRIPTION
* vm image `ubuntu-20.04` caused nuget package version issues. Reverting to 18.04 for now and will investigate a move to github actions instead of azure pipelines.