### PR TITLE
Fix: GraphField cloning was dropping some data fields

### DIFF
--- a/src/graphql-aspnet-subscriptions/Schemas/Structural/SubscriptionMethodGraphField.cs
+++ b/src/graphql-aspnet-subscriptions/Schemas/Structural/SubscriptionMethodGraphField.cs
@@ -50,11 +50,11 @@ namespace GraphQL.AspNet.Schemas.Structural
         }
 
         /// <inheritdoc />
-        protected override IGraphField CreateNewInstance(IGraphType parent)
+        protected override MethodGraphField CreateNewInstance(IGraphType parent)
         {
             return new SubscriptionMethodGraphField(
                 this.Name,
-                this.TypeExpression,
+                this.TypeExpression.Clone(),
                 parent.Route.CreateChild(this.Name),
                 this.ObjectType,
                 this.DeclaredReturnType,

--- a/src/graphql-aspnet/Interfaces/TypeSystem/IAppliedDirective.cs
+++ b/src/graphql-aspnet/Interfaces/TypeSystem/IAppliedDirective.cs
@@ -35,5 +35,11 @@ namespace GraphQL.AspNet.Interfaces.TypeSystem
         /// </summary>
         /// <value>The arguments.</value>
         object[] ArgumentValues { get; }
+
+        /// <summary>
+        /// Clones this instance and creates an independent copy.
+        /// </summary>
+        /// <returns>IAppliedDirective.</returns>
+        IAppliedDirective Clone();
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirective.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirective.cs
@@ -57,10 +57,14 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         /// <inheritdoc />
         public IAppliedDirective Clone()
         {
+            var arr = new object[this.ArgumentValues.Length];
+            if (arr.Length > 0)
+                Array.Copy(this.ArgumentValues, arr, arr.Length);
+
             if (this.DirectiveType != null)
-                return new AppliedDirective(this.DirectiveType, this.ArgumentValues.Clone());
+                return new AppliedDirective(this.DirectiveType, arr);
             else
-                return new AppliedDirective(this.DirectiveName, this.ArgumentValues.Clone());
+                return new AppliedDirective(this.DirectiveName, arr);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirective.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirective.cs
@@ -21,7 +21,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
     /// A class representing the application of a <see cref="GraphDirective"/>
     /// to a schema item.
     /// </summary>
-    [DebuggerDisplay("Directive = {DiagnosticName} (Arg Count = {Arguments.Length})")]
+    [DebuggerDisplay("Directive = {DiagnosticName} (Arg Count = {ArgumentValues.Length})")]
     public class AppliedDirective : IAppliedDirective
     {
         /// <summary>
@@ -52,6 +52,15 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
                 this.DirectiveName = this.DirectiveName.Substring(1);
 
             this.ArgumentValues = arguments;
+        }
+
+        /// <inheritdoc />
+        public IAppliedDirective Clone()
+        {
+            if (this.DirectiveType != null)
+                return new AppliedDirective(this.DirectiveType, this.ArgumentValues.Clone());
+            else
+                return new AppliedDirective(this.DirectiveName, this.ArgumentValues.Clone());
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirectiveCollection.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirectiveCollection.cs
@@ -45,7 +45,9 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public IAppliedDirectiveCollection Clone(ISchemaItem newParent)
         {
             var clone = new AppliedDirectiveCollection(newParent);
-            clone._appliedDirectives = new HashSet<IAppliedDirective>(_appliedDirectives, AppliedDirectiveEqualityComparer.Instance);
+            foreach (var directive in this)
+                clone.Add(directive.Clone());
+
             return clone;
         }
 

--- a/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirectiveEqualityComparer.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/AppliedDirectiveEqualityComparer.cs
@@ -34,12 +34,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         {
             if (x != null && y != null)
             {
-                if (x.DirectiveType != null && y.DirectiveType != null)
-                    return x.DirectiveType == y.DirectiveType;
-                else if (!string.IsNullOrWhiteSpace(x.DirectiveName) && !string.IsNullOrWhiteSpace(y.DirectiveName))
-                    return x.DirectiveName == y.DirectiveName;
-
-                return false;
+                return object.ReferenceEquals(x, y);
             }
             else if (x == null && y == null)
             {

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
@@ -33,7 +33,7 @@ namespace GraphQL.AspNet.Schemas.Structural
         /// <param name="route">The route path that identifies this argument.</param>
         /// <param name="modifiers">The modifiers.</param>
         /// <param name="parameterName">Name of the parameter as it is declared in the source code.</param>
-        /// <param name="internalname">The fully qualified internal name identifiying this argument.</param>
+        /// <param name="internalName">The fully qualified internal name identifiying this argument.</param>
         /// <param name="objectType">The concrete type of the object representing this argument.</param>
         /// <param name="hasDefaultValue">if set to <c>true</c> indicates that this
         /// argument has a default value assigned, even if that argument is <c>null</c>.</param>
@@ -48,7 +48,7 @@ namespace GraphQL.AspNet.Schemas.Structural
             SchemaItemPath route,
             GraphArgumentModifiers modifiers,
             string parameterName,
-            string internalname,
+            string internalName,
             Type objectType,
             bool hasDefaultValue,
             object defaultValue = null,
@@ -58,7 +58,7 @@ namespace GraphQL.AspNet.Schemas.Structural
             this.Parent = Validation.ThrowIfNullOrReturn(parent, nameof(parent));
             this.Name = Validation.ThrowIfNullWhiteSpaceOrReturn(argumentName, nameof(argumentName));
             this.Route = Validation.ThrowIfNullOrReturn(route, nameof(route));
-            this.InternalName = Validation.ThrowIfNullWhiteSpaceOrReturn(internalname, nameof(internalname));
+            this.InternalName = Validation.ThrowIfNullWhiteSpaceOrReturn(internalName, nameof(internalName));
             this.ParameterName = Validation.ThrowIfNullWhiteSpaceOrReturn(parameterName, nameof(parameterName));
             this.TypeExpression = Validation.ThrowIfNullOrReturn(typeExpression, nameof(typeExpression));
             this.ObjectType = Validation.ThrowIfNullOrReturn(objectType, nameof(objectType));
@@ -77,7 +77,7 @@ namespace GraphQL.AspNet.Schemas.Structural
             return new GraphFieldArgument(
                 parent,
                 this.Name,
-                this.TypeExpression,
+                this.TypeExpression.Clone(),
                 parent.Route.CreateChild(this.Name),
                 this.ArgumentModifiers,
                 this.ParameterName,

--- a/src/graphql-aspnet/Schemas/TypeSystem/MethodGraphField.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/MethodGraphField.cs
@@ -95,6 +95,7 @@ namespace GraphQL.AspNet.Schemas.Structural
 
             var newField = this.CreateNewInstance(parent);
 
+            // assign all publically alterable fields
             newField.Description = this.Description;
             newField.Publish = this.Publish;
             newField.Complexity = this.Complexity;
@@ -104,6 +105,7 @@ namespace GraphQL.AspNet.Schemas.Structural
 
             newField.AssignParent(parent);
 
+            // clone over the arguments
             foreach (var argument in this.Arguments)
                 newField.Arguments.AddArgument(argument.Clone(newField));
 
@@ -138,6 +140,9 @@ namespace GraphQL.AspNet.Schemas.Structural
         /// <summary>
         /// Creates a new instance of a graph field from this type.
         /// </summary>
+        /// <remarks>
+        /// This method is used as the basis for new object creation during cloning.
+        /// </remarks>
         /// <param name="parent">The item to assign as the parent of the new field.</param>
         /// <returns>IGraphField.</returns>
         protected virtual MethodGraphField CreateNewInstance(IGraphType parent)

--- a/src/graphql-aspnet/Schemas/TypeSystem/MethodGraphField.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/MethodGraphField.cs
@@ -94,6 +94,14 @@ namespace GraphQL.AspNet.Schemas.Structural
             Validation.ThrowIfNull(parent, nameof(parent));
 
             var newField = this.CreateNewInstance(parent);
+
+            newField.Description = this.Description;
+            newField.Publish = this.Publish;
+            newField.Complexity = this.Complexity;
+            newField.IsDeprecated = this.IsDeprecated;
+            newField.DeprecationReason = this.DeprecationReason;
+            newField.FieldSource = this.FieldSource;
+
             newField.AssignParent(parent);
 
             foreach (var argument in this.Arguments)
@@ -132,11 +140,11 @@ namespace GraphQL.AspNet.Schemas.Structural
         /// </summary>
         /// <param name="parent">The item to assign as the parent of the new field.</param>
         /// <returns>IGraphField.</returns>
-        protected virtual IGraphField CreateNewInstance(IGraphType parent)
+        protected virtual MethodGraphField CreateNewInstance(IGraphType parent)
         {
             return new MethodGraphField(
                 this.Name,
-                this.TypeExpression,
+                this.TypeExpression.Clone(),
                 parent.Route.CreateChild(this.Name),
                 this.ObjectType,
                 this.DeclaredReturnType,

--- a/src/graphql-aspnet/Schemas/TypeSystem/PropertyGraphField.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/PropertyGraphField.cs
@@ -56,11 +56,11 @@ namespace GraphQL.AspNet.Schemas.Structural
         /// </summary>
         /// <param name="parent">The item to assign as the parent of the new field.</param>
         /// <returns>IGraphField.</returns>
-        protected override IGraphField CreateNewInstance(IGraphType parent)
+        protected override MethodGraphField CreateNewInstance(IGraphType parent)
         {
             return new PropertyGraphField(
                 this.Name,
-                this.TypeExpression,
+                this.TypeExpression.Clone(),
                 parent.Route.CreateChild(this.Name),
                 this.InternalName,
                 this.ObjectType,

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/InterfaceAForIntrospection.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/InterfaceAForIntrospection.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.IntrospectionTestData
+{
+    using System.ComponentModel;
+
+    public interface InterfaceAForIntrospection
+    {
+        [Description("Description of field A")]
+        string FieldA { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/InterfaceBForIntrospection.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/InterfaceBForIntrospection.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.IntrospectionTestData
+{
+    using System.ComponentModel;
+
+    public interface InterfaceBForIntrospection : InterfaceAForIntrospection
+    {
+        [Description("Description of field B")]
+        string FieldB { get; set; }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/TypeExtensionDescriptionController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/TypeExtensionDescriptionController.cs
@@ -1,0 +1,36 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.IntrospectionTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using NUnit.Framework;
+
+    public class TypeExtensionDescriptionController : GraphController
+    {
+        [QueryRoot]
+        public TwoPropertyObject RetrieveObject(string prop1Value)
+        {
+            return new TwoPropertyObject()
+            {
+                Property1 = prop1Value,
+                Property2 = prop1Value.Length,
+            };
+        }
+
+        [Description("Property3 is a boolean")]
+        [TypeExtension(typeof(TwoPropertyObject), "property3", typeof(bool))]
+        public bool TwoProp_Property3(TwoPropertyObject obj)
+        {
+            return obj.Property1 == "bob";
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/TypeExtensionDescriptionController.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTestData/TypeExtensionDescriptionController.cs
@@ -9,10 +9,10 @@
 
 namespace GraphQL.AspNet.Tests.Execution.IntrospectionTestData
 {
+    using System.ComponentModel;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
-    using NUnit.Framework;
 
     public class TypeExtensionDescriptionController : GraphController
     {

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
@@ -1914,7 +1914,7 @@ namespace GraphQL.AspNet.Tests.Execution
                             {
                                 ""name"": ""property2"",
                                 ""description"": null
-                            }
+                            },
                             {
                                 ""name"": ""property3"",
                                 ""description"": ""Property3 is a boolean""
@@ -1926,8 +1926,6 @@ namespace GraphQL.AspNet.Tests.Execution
 
             CommonAssertions.AreEqualJsonStrings(expectedResponse, response);
         }
-
-
 
         [Test]
         public async Task Descriptions_OnInheritedInterfaces_AreRetrievedViaIntrospection()

--- a/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
@@ -1876,5 +1876,112 @@ namespace GraphQL.AspNet.Tests.Execution
 
             CommonAssertions.AreEqualJsonStrings(expectedResponse, response);
         }
+
+        [Test]
+        public async Task Description_OnTypeExtensionField_IsRetrievedViaIntrospection()
+        {
+            var server = new TestServerBuilder()
+                .AddGraphController<TypeExtensionDescriptionController>()
+                .Build();
+
+            var builder = server.CreateQueryContextBuilder();
+            builder.AddQueryText(@"
+                {
+                    __type(name: ""TwoPropertyObject"")
+                    {
+                        kind
+                        name
+                        fields(includeDeprecated: true) {
+                            name
+                            description
+                        }
+                    }
+                }");
+
+            // property3 is a type extension and has a declared description
+            var response = await server.RenderResult(builder);
+            var expectedResponse = @"
+            {
+                ""data"": {
+                    ""__type"": {
+                        ""kind"": ""OBJECT"",
+                        ""name"": ""TwoPropertyObject"",
+                        ""fields"": [
+                            {
+                                ""name"": ""property1"",
+                                ""description"": null
+                            },
+                            {
+                                ""name"": ""property2"",
+                                ""description"": null
+                            }
+                            {
+                                ""name"": ""property3"",
+                                ""description"": ""Property3 is a boolean""
+                            }
+                        ]
+                    }
+                }
+            }";
+
+            CommonAssertions.AreEqualJsonStrings(expectedResponse, response);
+        }
+
+
+
+        [Test]
+        public async Task Descriptions_OnInheritedInterfaces_AreRetrievedViaIntrospection()
+        {
+            var server = new TestServerBuilder()
+                .AddType<InterfaceAForIntrospection>()
+                .AddType<InterfaceBForIntrospection>()
+                .Build();
+
+            var builder = server.CreateQueryContextBuilder();
+            builder.AddQueryText(@"
+                {
+                    __type(name: ""InterfaceBForIntrospection"")
+                    {
+                        kind
+                        name
+                        interfaces{ name }
+                        fields(includeDeprecated: true) {
+                            name
+                            description
+                        }
+                    }
+                }");
+
+            // description for field A is declared on interface A
+            // description for field B is declared on interface B
+            // both descriptions hould show as part of the fields for interface B
+            var response = await server.RenderResult(builder);
+            var expectedResponse = @"
+            {
+                ""data"": {
+                    ""__type"": {
+                        ""kind"": ""INTERFACE"",
+                        ""name"": ""InterfaceBForIntrospection"",
+                        ""interfaces"" : [
+                                {
+                                    ""name"": ""InterfaceAForIntrospection""
+                                }
+                        ],
+                        ""fields"": [
+                            {
+                                ""name"": ""fieldA"",
+                                ""description"": ""Description of field A""
+                            },
+                            {
+                                ""name"": ""fieldB"",
+                                ""description"": ""Description of field B""
+                            }
+                        ]
+                    }
+                }
+            }";
+
+            CommonAssertions.AreEqualJsonStrings(expectedResponse, response);
+        }
     }
 }

--- a/src/tests/graphql-aspnet-tests/Schemas/AppliedDirectiveCollectionTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/AppliedDirectiveCollectionTests.cs
@@ -1,0 +1,81 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas
+{
+    using GraphQL.AspNet.Directives.Global;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AppliedDirectiveCollectionTests
+    {
+        [Test]
+        public void DirectivesWithDifferentTypesAreAdded()
+        {
+            var collection = new AppliedDirectiveCollection();
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective)));
+            collection.Add(new AppliedDirective(typeof(SpecifiedByDirective)));
+
+            Assert.AreEqual(2, collection.Count);
+        }
+
+        [Test]
+        public void AddingTheSameDirectiveTwiceFails()
+        {
+            var collection = new AppliedDirectiveCollection();
+
+            var directive = new AppliedDirective(typeof(DeprecatedDirective), "Reason 1");
+            collection.Add(directive);
+            collection.Add(directive);
+
+            Assert.AreEqual(1, collection.Count);
+        }
+
+        [Test]
+        public void DirectivesWithSameArgsAreAdded()
+        {
+            var collection = new AppliedDirectiveCollection();
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective), "Reason 1"));
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective), "Reason 1"));
+
+            Assert.AreEqual(2, collection.Count);
+        }
+
+        [Test]
+        public void DirectivesWithDifferentArgsAreAdded()
+        {
+            var collection = new AppliedDirectiveCollection();
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective), "Reason 1"));
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective), "Reason 2"));
+
+            Assert.AreEqual(2, collection.Count);
+        }
+
+        [Test]
+        public void DirectivesWithDifferentNamesAreAdded()
+        {
+            var collection = new AppliedDirectiveCollection();
+            collection.Add(new AppliedDirective("deprecated"));
+            collection.Add(new AppliedDirective("specifiedBy"));
+
+            Assert.AreEqual(2, collection.Count);
+        }
+
+        [Test]
+        public void DirectivesOfVaryingTypesAreAdded()
+        {
+            var collection = new AppliedDirectiveCollection();
+            collection.Add(new AppliedDirective(typeof(DeprecatedDirective)));
+            collection.Add(new AppliedDirective("deprecated"));
+
+            Assert.AreEqual(2, collection.Count);
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/GraphFieldArgumentCloningTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/GraphFieldArgumentCloningTests.cs
@@ -1,0 +1,67 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas
+{
+    using GraphQL.AspNet.Interfaces.TypeSystem;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Schemas.Structural;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+    using Moq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class GraphFieldArgumentCloningTests
+    {
+        [Test]
+        public void ClonedArgument_PropertyCheck()
+        {
+            var directives = new AppliedDirectiveCollection();
+            directives.Add(new AppliedDirective("directive1", 3));
+
+            var parentField = new Mock<ISchemaItem>();
+            parentField.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/GraphType1/Field1"));
+            parentField.Setup(x => x.Name).Returns("Field1");
+
+            var arg = new GraphFieldArgument(
+                parentField.Object,
+                "argName",
+                GraphTypeExpression.FromDeclaration("String"),
+                new SchemaItemPath("[type]/GraphType1/Field1/Arg1"),
+                GraphArgumentModifiers.Internal,
+                "paramName",
+                "internalName",
+                typeof(string),
+                true,
+                "default value",
+                "a description",
+                directives);
+
+            var newParentField = new Mock<ISchemaItem>();
+            newParentField.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/GraphType2/Field1"));
+            newParentField.Setup(x => x.Name).Returns("Field1");
+
+            var clonedArg = arg.Clone(newParentField.Object) as GraphFieldArgument;
+
+            Assert.AreEqual(arg.Name, clonedArg.Name);
+            Assert.AreEqual(arg.Description, clonedArg.Description);
+            Assert.AreEqual(arg.DefaultValue, clonedArg.DefaultValue);
+            Assert.AreEqual(arg.ObjectType, clonedArg.ObjectType);
+            Assert.AreEqual(arg.InternalName, clonedArg.InternalName);
+            Assert.AreEqual(arg.ArgumentModifiers, clonedArg.ArgumentModifiers);
+            Assert.AreEqual(arg.TypeExpression, clonedArg.TypeExpression);
+            Assert.AreEqual(arg.ParameterName, clonedArg.ParameterName);
+            Assert.AreEqual(arg.AppliedDirectives.Count, arg.AppliedDirectives.Count);
+
+            Assert.IsFalse(object.ReferenceEquals(arg.AppliedDirectives, clonedArg.AppliedDirectives));
+            Assert.IsFalse(object.ReferenceEquals(arg.Parent, clonedArg.Parent));
+            Assert.IsFalse(object.ReferenceEquals(arg.TypeExpression, clonedArg.TypeExpression));
+        }
+    }
+}

--- a/src/tests/graphql-aspnet-tests/Schemas/GraphFieldCloningTests.cs
+++ b/src/tests/graphql-aspnet-tests/Schemas/GraphFieldCloningTests.cs
@@ -1,0 +1,192 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using GraphQL.AspNet.Interfaces.Execution;
+    using GraphQL.AspNet.Interfaces.TypeSystem;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Schemas.Structural;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+    using GraphQL.AspNet.Security;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using Microsoft.AspNetCore.Authorization;
+    using Moq;
+    using NUnit.Framework;
+
+    [AllowAnonymous]
+    [TestFixture]
+    public class GraphFieldCloningTests
+    {
+        [Test]
+        public void MethodField_PropertyCheck()
+        {
+            var originalParent = new Mock<IGraphType>();
+            originalParent.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/JohnType"));
+            originalParent.Setup(x => x.Name).Returns("JohnType");
+
+            var resolver = new Mock<IGraphFieldResolver>();
+            var polices = new List<AppliedSecurityPolicyGroup>();
+            polices.Add(AppliedSecurityPolicyGroup.FromAttributeCollection(typeof(GraphFieldCloningTests)));
+
+            var appliedDirectives = new AppliedDirectiveCollection();
+            appliedDirectives.Add(new AppliedDirective("someDirective", 3));
+
+            var field = new MethodGraphField(
+                "field1",
+                GraphTypeExpression.FromDeclaration("[Int]"),
+                new SchemaItemPath("[type]/JohnType/field1"),
+                typeof(TwoPropertyObject),
+                typeof(List<TwoPropertyObject>),
+                AspNet.Execution.FieldResolutionMode.PerSourceItem,
+                resolver.Object,
+                polices,
+                appliedDirectives);
+
+            field.AssignParent(originalParent.Object);
+
+            field.Arguments.AddArgument(new GraphFieldArgument(
+                field,
+                "arg1",
+                GraphTypeExpression.FromDeclaration("String"),
+                field.Route.CreateChild("arg1"),
+                GraphArgumentModifiers.None,
+                "arg1",
+                "arg1",
+                typeof(string),
+                false));
+
+            field.Complexity = 1.3f;
+            field.IsDeprecated = true;
+            field.DeprecationReason = "Because I said so";
+            field.Publish = false;
+            field.FieldSource = AspNet.Internal.TypeTemplates.GraphFieldSource.Method;
+
+            var clonedParent = new Mock<IGraphType>();
+            clonedParent.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/BobType"));
+            clonedParent.Setup(x => x.Name).Returns("BobType");
+            var clonedField = field.Clone(clonedParent.Object);
+
+            Assert.AreEqual(field.Name, clonedField.Name);
+            Assert.AreEqual(field.ObjectType, clonedField.ObjectType);
+            Assert.AreEqual(field.DeclaredReturnType, clonedField.DeclaredReturnType);
+            Assert.AreEqual(clonedField.TypeExpression.ToString(), clonedField.TypeExpression.ToString());
+            Assert.AreEqual(field.Description, clonedField.Description);
+            Assert.AreEqual(field.Publish, clonedField.Publish);
+            Assert.AreEqual("[type]/BobType/field1", clonedField.Route.Path);
+            Assert.AreEqual(field.Mode, clonedField.Mode);
+            Assert.AreEqual(field.IsLeaf, clonedField.IsLeaf);
+            Assert.AreEqual(field.IsDeprecated, clonedField.IsDeprecated);
+            Assert.AreEqual(field.DeprecationReason, clonedField.DeprecationReason);
+            Assert.AreEqual(field.Complexity, clonedField.Complexity);
+            Assert.AreEqual(field.FieldSource, clonedField.FieldSource);
+
+            Assert.IsFalse(object.ReferenceEquals(field.TypeExpression, clonedField.TypeExpression));
+            Assert.IsTrue(object.ReferenceEquals(field.Resolver, clonedField.Resolver));
+            Assert.IsFalse(object.ReferenceEquals(field.AppliedDirectives, clonedField.AppliedDirectives));
+            Assert.IsFalse(object.ReferenceEquals(field.SecurityGroups, clonedField.SecurityGroups));
+            Assert.IsFalse(object.ReferenceEquals(field.Arguments, clonedField.Arguments));
+
+            Assert.AreEqual(field.AppliedDirectives.Count, clonedField.AppliedDirectives.Count);
+            Assert.AreEqual(field.SecurityGroups.Count(), clonedField.SecurityGroups.Count());
+            Assert.AreEqual(field.Arguments.Count, clonedField.Arguments.Count);
+
+            foreach (var arg in field.Arguments)
+            {
+                var foundArg = clonedField.Arguments.FindArgument(arg.Name);
+                Assert.IsNotNull(foundArg);
+            }
+        }
+
+        [Test]
+        public void PropertyField_PropertyCheck()
+        {
+            var originalParent = new Mock<IGraphType>();
+            originalParent.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/JohnType"));
+            originalParent.Setup(x => x.Name).Returns("JohnType");
+
+            var resolver = new Mock<IGraphFieldResolver>();
+            var polices = new List<AppliedSecurityPolicyGroup>();
+            polices.Add(AppliedSecurityPolicyGroup.FromAttributeCollection(typeof(GraphFieldCloningTests)));
+
+            var appliedDirectives = new AppliedDirectiveCollection();
+            appliedDirectives.Add(new AppliedDirective("someDirective", 3));
+
+            var field = new PropertyGraphField(
+                "field1",
+                GraphTypeExpression.FromDeclaration("[Int]"),
+                new SchemaItemPath("[type]/JohnType/field1"),
+                "Prop1",
+                typeof(TwoPropertyObject),
+                typeof(List<TwoPropertyObject>),
+                AspNet.Execution.FieldResolutionMode.PerSourceItem,
+                resolver.Object,
+                polices,
+                appliedDirectives);
+
+            field.AssignParent(originalParent.Object);
+
+            field.Arguments.AddArgument(new GraphFieldArgument(
+                field,
+                "arg1",
+                GraphTypeExpression.FromDeclaration("String"),
+                field.Route.CreateChild("arg1"),
+                GraphArgumentModifiers.None,
+                "arg1",
+                "arg1",
+                typeof(string),
+                false));
+
+            field.Complexity = 1.3f;
+            field.IsDeprecated = true;
+            field.DeprecationReason = "Because I said so";
+            field.Publish = false;
+            field.FieldSource = AspNet.Internal.TypeTemplates.GraphFieldSource.Method;
+
+            var clonedParent = new Mock<IGraphType>();
+            clonedParent.Setup(x => x.Route).Returns(new SchemaItemPath("[type]/BobType"));
+            clonedParent.Setup(x => x.Name).Returns("BobType");
+            var clonedField = field.Clone(clonedParent.Object) as PropertyGraphField;
+
+            Assert.IsNotNull(clonedField);
+            Assert.AreEqual(field.InternalName, clonedField.InternalName);
+            Assert.AreEqual(field.Name, clonedField.Name);
+            Assert.AreEqual(field.ObjectType, clonedField.ObjectType);
+            Assert.AreEqual(field.DeclaredReturnType, clonedField.DeclaredReturnType);
+            Assert.AreEqual(clonedField.TypeExpression.ToString(), clonedField.TypeExpression.ToString());
+            Assert.AreEqual(field.Description, clonedField.Description);
+            Assert.AreEqual(field.Publish, clonedField.Publish);
+            Assert.AreEqual("[type]/BobType/field1", clonedField.Route.Path);
+            Assert.AreEqual(field.Mode, clonedField.Mode);
+            Assert.AreEqual(field.IsLeaf, clonedField.IsLeaf);
+            Assert.AreEqual(field.IsDeprecated, clonedField.IsDeprecated);
+            Assert.AreEqual(field.DeprecationReason, clonedField.DeprecationReason);
+            Assert.AreEqual(field.Complexity, clonedField.Complexity);
+            Assert.AreEqual(field.FieldSource, clonedField.FieldSource);
+
+            Assert.IsFalse(object.ReferenceEquals(field.TypeExpression, clonedField.TypeExpression));
+            Assert.IsTrue(object.ReferenceEquals(field.Resolver, clonedField.Resolver));
+            Assert.IsFalse(object.ReferenceEquals(field.AppliedDirectives, clonedField.AppliedDirectives));
+            Assert.IsFalse(object.ReferenceEquals(field.SecurityGroups, clonedField.SecurityGroups));
+            Assert.IsFalse(object.ReferenceEquals(field.Arguments, clonedField.Arguments));
+
+            Assert.AreEqual(field.AppliedDirectives.Count, clonedField.AppliedDirectives.Count);
+            Assert.AreEqual(field.SecurityGroups.Count(), clonedField.SecurityGroups.Count());
+            Assert.AreEqual(field.Arguments.Count, clonedField.Arguments.Count);
+
+            foreach (var arg in field.Arguments)
+            {
+                var foundArg = clonedField.Arguments.FindArgument(arg.Name);
+                Assert.IsNotNull(foundArg);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Fixed a bug where by when a graph field definition is cloned for use as a `[TypeExtension]`  or when an interface field is cloned for application to other inherited interfaces some auxiliary data fields were not correctly cloned and were inadvertently dropped.

Fields that were not correctly cloned but have been fixed:
* `Description`
* `Publish`
* `Complexity`
* `IsDeprecated`
* `DepreciationReason`
* `FieldSource`