### PR TITLE
Removed Old Naming For Request and Result

### DIFF
--- a/src/graphql-aspnet-subscriptions/Middleware/QueryExecution/Components/SubscriptionCreationMiddleware.cs
+++ b/src/graphql-aspnet-subscriptions/Middleware/QueryExecution/Components/SubscriptionCreationMiddleware.cs
@@ -33,7 +33,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
             {
                 subContext.Subscription = new ClientSubscription<TSchema>(
                     subContext.Client,
-                    subContext.OperationRequest.ToDataPackage(),
+                    subContext.QueryRequest.ToDataPackage(),
                     subContext.QueryPlan,
                     subContext.SubscriptionId);
 

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
@@ -138,7 +138,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
                     else
                     {
                         // report everything else as a completed request via "next"
-                        var responseMessage = new GqltwsServerNextDataMessage(message.Id, result.OperationResult);
+                        var responseMessage = new GqltwsServerNextDataMessage(message.Id, result.QueryResult);
                         var completedMessage = new GqltwsSubscriptionCompleteMessage(message.Id);
 
                         await this.SendMessageAsync(responseMessage).ConfigureAwait(false);
@@ -324,9 +324,9 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
         }
 
         /// <inheritdoc />
-        protected override GqltwsMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult operationResult)
+        protected override GqltwsMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult queryResult)
         {
-            return new GqltwsServerNextDataMessage(subscriptionId, operationResult);
+            return new GqltwsServerNextDataMessage(subscriptionId, queryResult);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
@@ -276,7 +276,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
                     }
                     else
                     {
-                        responseMessage = new GraphqlWsLegacyServerDataMessage(message.Id, result.OperationResult);
+                        responseMessage = new GraphqlWsLegacyServerDataMessage(message.Id, result.QueryResult);
                     }
 
                     await this.SendMessageAsync(responseMessage).ConfigureAwait(false);
@@ -311,9 +311,9 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
         }
 
         /// <inheritdoc />
-        protected override GraphqlWsLegacyMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult operationResult)
+        protected override GraphqlWsLegacyMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult queryResult)
         {
-            return new GraphqlWsLegacyServerDataMessage(subscriptionId, operationResult);
+            return new GraphqlWsLegacyServerDataMessage(subscriptionId, queryResult);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/SubscriptionClientProxyBase{TSchema,TMessage}.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/SubscriptionClientProxyBase{TSchema,TMessage}.cs
@@ -143,9 +143,9 @@ namespace GraphQL.AspNet.SubscriptionServer
         /// </summary>
         /// <param name="subscriptionId">The unqiue identifier provided by the client
         /// that identifies what series of operations this result belongs to.</param>
-        /// <param name="operationResult">The data result to transmit.</param>
+        /// <param name="queryResult">The data result to transmit.</param>
         /// <returns>TMessage.</returns>
-        protected abstract TMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult operationResult);
+        protected abstract TMessage CreateDataMessage(string subscriptionId, IQueryExecutionResult queryResult);
 
         /// <summary>
         /// Creates a message consistant with this proxy's underlying protocol

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/SubscriptionQueryExecutionResult.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/SubscriptionQueryExecutionResult.cs
@@ -90,17 +90,17 @@ namespace GraphQL.AspNet.SubscriptionServer
         /// successfully executed and no subscription was created.
         /// </summary>
         /// <param name="subscriptionId">The subscription id that was executed.</param>
-        /// <param name="operationResult">The completed query operation result.</param>
+        /// <param name="queryResult">The completed query operation result.</param>
         /// <returns>SubscriptionDataExecutionResult&lt;TSchema&gt;.</returns>
-        public static SubscriptionQueryExecutionResult<TSchema> SingleOperationCompleted(string subscriptionId, IQueryExecutionResult operationResult)
+        public static SubscriptionQueryExecutionResult<TSchema> SingleOperationCompleted(string subscriptionId, IQueryExecutionResult queryResult)
         {
             var result = new SubscriptionQueryExecutionResult<TSchema>();
             result.SubscriptionId = subscriptionId;
 
             result.Status = SubscriptionQueryResultType.SingleQueryCompleted;
 
-            result.OperationResult = operationResult;
-            result.Messages = operationResult.Messages;
+            result.QueryResult = queryResult;
+            result.Messages = queryResult.Messages;
 
             return result;
         }
@@ -129,12 +129,12 @@ namespace GraphQL.AspNet.SubscriptionServer
         /// null if the executed operation registered a <see cref="Subscription"/> instead.
         /// </summary>
         /// <value>The operation result.</value>
-        public IQueryExecutionResult OperationResult { get; private set; }
+        public IQueryExecutionResult QueryResult { get; private set; }
 
         /// <summary>
         /// Gets the subscription that was created if the executed query was a
         /// subscription based query that was completed. Will be null of the executed operation
-        /// generated a <see cref="OperationResult"/> instead.
+        /// generated a <see cref="QueryResult"/> instead.
         /// </summary>
         /// <value>The subscription.</value>
         public ISubscription<TSchema> Subscription { get; private set; }

--- a/src/graphql-aspnet/Controllers/GraphControllerBase.cs
+++ b/src/graphql-aspnet/Controllers/GraphControllerBase.cs
@@ -58,7 +58,7 @@ namespace GraphQL.AspNet.Controllers
 
             _schemaItemContext.Logger?.ActionMethodInvocationRequestStarted(_action, this.Request);
 
-            if (_schemaItemContext.OperationRequest is IQueryExecutionWebRequest webRequest)
+            if (_schemaItemContext.QueryRequest is IQueryExecutionWebRequest webRequest)
                 this.HttpContext = webRequest.HttpContext;
 
             if (_action?.Method == null)
@@ -143,7 +143,7 @@ namespace GraphQL.AspNet.Controllers
         public InputModelStateDictionary ModelState { get; private set; }
 
         /// <summary>
-        /// Gets the raw request for this operation provided by the action invoker.
+        /// Gets the raw request for this request provided by the action invoker.
         /// </summary>
         /// <value>The field context.</value>
         [GraphSkip]

--- a/src/graphql-aspnet/Engine/DefaultGraphQLHttpProcessor{TSchema}.cs
+++ b/src/graphql-aspnet/Engine/DefaultGraphQLHttpProcessor{TSchema}.cs
@@ -124,7 +124,7 @@ namespace GraphQL.AspNet.Engine
         /// </summary>
         /// <param name="queryData">The query data parsed from an <see cref="HttpRequest" />; may be null.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IActionResult&gt;.</returns>
+        /// <returns>Task.</returns>
         protected virtual async Task SubmitQueryAsync(GraphQueryData queryData, CancellationToken cancelToken = default)
         {
             // ensure data was received
@@ -143,7 +143,7 @@ namespace GraphQL.AspNet.Engine
         /// </summary>
         /// <param name="queryData">The query data.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IGraphOperationResult&gt;.</returns>
+        /// <returns>Task.</returns>
         protected virtual async Task ExecuteQueryAsync(GraphQueryData queryData, CancellationToken cancelToken = default)
         {
             try
@@ -151,14 +151,14 @@ namespace GraphQL.AspNet.Engine
                 // *******************************
                 // Setup
                 // *******************************
-                var request = await this.CreateOperationRequestAsync(queryData, cancelToken);
+                var request = await this.CreateQueryRequestAsync(queryData, cancelToken);
                 if (request == null)
                 {
                     await this.WriteStatusCodeResponseAsync(HttpStatusCode.InternalServerError, ERROR_NO_REQUEST_CREATED, cancelToken).ConfigureAwait(false);
                     return;
                 }
 
-                this.GraphQLOperationRequest = request;
+                this.GraphQLQueryRequest = request;
                 var securityContext = this.CreateUserSecurityContext();
 
                 // *******************************
@@ -167,7 +167,7 @@ namespace GraphQL.AspNet.Engine
                 var queryResponse = await _runtime
                     .ExecuteRequestAsync(
                         this.HttpContext.RequestServices,
-                        this.GraphQLOperationRequest,
+                        this.GraphQLQueryRequest,
                         securityContext,
                         this.EnableMetrics,
                         cancelToken)
@@ -218,8 +218,8 @@ namespace GraphQL.AspNet.Engine
         /// </summary>
         /// <param name="queryData">The query data that needs to be packaged into a <see cref="IQueryExecutionRequest" />.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>IGraphOperationRequest.</returns>
-        protected virtual Task<IQueryExecutionRequest> CreateOperationRequestAsync(GraphQueryData queryData, CancellationToken cancelToken = default)
+        /// <returns>IQueryExecutionRequest.</returns>
+        protected virtual Task<IQueryExecutionRequest> CreateQueryRequestAsync(GraphQueryData queryData, CancellationToken cancelToken = default)
         {
             var request = _runtime.CreateRequest(queryData);
             if (request == null)
@@ -321,7 +321,7 @@ namespace GraphQL.AspNet.Engine
             string message,
             string errorCode = Constants.ErrorCodes.GENERAL_ERROR)
         {
-            var response = new QueryExecutionResult(this.GraphQLOperationRequest);
+            var response = new QueryExecutionResult(this.GraphQLQueryRequest);
             response.Messages.Add(GraphMessageSeverity.Critical, message, errorCode);
             return response;
         }
@@ -386,9 +386,9 @@ namespace GraphQL.AspNet.Engine
         /// Gets the GraphQL request that was created and processed.
         /// </summary>
         /// <remarks>
-        /// This property may not be populated until after <see cref="CreateOperationRequestAsync"/> is called.
+        /// This property may not be populated until after <see cref="CreateQueryRequestAsync"/> is called.
         /// </remarks>
         /// <value>The graphQL request being executed by this processor.</value>
-        protected virtual IQueryExecutionRequest GraphQLOperationRequest { get; private set; }
+        protected virtual IQueryExecutionRequest GraphQLQueryRequest { get; private set; }
     }
 }

--- a/src/graphql-aspnet/Engine/DefaultGraphQLRuntime.cs
+++ b/src/graphql-aspnet/Engine/DefaultGraphQLRuntime.cs
@@ -148,7 +148,7 @@ namespace GraphQL.AspNet.Engine
             var queryResponse = context.Result;
             if (queryResponse == null)
             {
-                queryResponse = new QueryExecutionResult(context.OperationRequest);
+                queryResponse = new QueryExecutionResult(context.QueryRequest);
                 queryResponse.Messages.Add(GraphMessageSeverity.Critical, ERROR_NO_RESPONSE, Constants.ErrorCodes.GENERAL_ERROR);
                 context.Result = queryResponse;
             }

--- a/src/graphql-aspnet/Execution/Contexts/GraphDirectiveExecutionContext.cs
+++ b/src/graphql-aspnet/Execution/Contexts/GraphDirectiveExecutionContext.cs
@@ -54,7 +54,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         /// </summary>
         /// <param name="schema">The schema this context targets.</param>
         /// <param name="directiveRequest">The directive request to be completed.</param>
-        /// <param name="operationRequest">The parent operation under which
+        /// <param name="queryRequest">The parent request under which
         /// this directive execution is taking place.</param>
         /// <param name="serviceProvider">The service provider used to resolve needed
         /// objects for this context.</param>
@@ -69,7 +69,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         public GraphDirectiveExecutionContext(
             ISchema schema,
             IGraphDirectiveRequest directiveRequest,
-            IQueryExecutionRequest operationRequest,
+            IQueryExecutionRequest queryRequest,
             IServiceProvider serviceProvider,
             IQuerySession querySession,
             IUserSecurityContext userSecurityContext = null,
@@ -79,7 +79,7 @@ namespace GraphQL.AspNet.Execution.Contexts
             IResolvedVariableCollection variableData = null,
             ClaimsPrincipal user = null)
             : base(
-                  operationRequest,
+                  queryRequest,
                   serviceProvider,
                   querySession,
                   userSecurityContext,

--- a/src/graphql-aspnet/Execution/Contexts/MiddlewareExecutionContextBase.cs
+++ b/src/graphql-aspnet/Execution/Contexts/MiddlewareExecutionContextBase.cs
@@ -30,7 +30,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         /// <param name="otherContext">The other context on which this context is based.</param>
         protected MiddlewareExecutionContextBase(IGraphQLMiddlewareExecutionContext otherContext)
             : this(
-                    otherContext?.OperationRequest,
+                    otherContext?.QueryRequest,
                     otherContext?.ServiceProvider,
                     otherContext?.Session,
                     otherContext?.SecurityContext,
@@ -44,7 +44,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         /// <summary>
         /// Initializes a new instance of the <see cref="MiddlewareExecutionContextBase" /> class.
         /// </summary>
-        /// <param name="operationRequest">The original operation request.</param>
+        /// <param name="queryRequest">The original operation request.</param>
         /// <param name="serviceProvider">The service provider passed on the HttpContext.</param>
         /// <param name="querySession">The query session governing the execution of a query.</param>
         /// <param name="securityContext">The security context used to authenticate
@@ -54,7 +54,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         /// <param name="logger">The logger instance to record events related to this context.</param>
         /// <param name="cancelToken">The cancel token governing this execution context.</param>
         protected MiddlewareExecutionContextBase(
-            IQueryExecutionRequest operationRequest,
+            IQueryExecutionRequest queryRequest,
             IServiceProvider serviceProvider,
             IQuerySession querySession,
             IUserSecurityContext securityContext = null,
@@ -63,7 +63,7 @@ namespace GraphQL.AspNet.Execution.Contexts
             IGraphEventLogger logger = null,
             CancellationToken cancelToken = default)
         {
-            this.OperationRequest = Validation.ThrowIfNullOrReturn(operationRequest, nameof(operationRequest));
+            this.QueryRequest = Validation.ThrowIfNullOrReturn(queryRequest, nameof(queryRequest));
             this.ServiceProvider = Validation.ThrowIfNullOrReturn(serviceProvider, nameof(serviceProvider));
             this.Session = Validation.ThrowIfNullOrReturn(querySession, nameof(Session));
 
@@ -104,7 +104,7 @@ namespace GraphQL.AspNet.Execution.Contexts
         public bool IsValid => !this.Messages.Severity.IsCritical();
 
         /// <inheritdoc />
-        public IQueryExecutionRequest OperationRequest { get; }
+        public IQueryExecutionRequest QueryRequest { get; }
 
         /// <inheritdoc />
         public CancellationToken CancellationToken { get; set; }

--- a/src/graphql-aspnet/Execution/DirectiveProcessorTypeSystem.cs
+++ b/src/graphql-aspnet/Execution/DirectiveProcessorTypeSystem.cs
@@ -119,7 +119,7 @@ namespace GraphQL.AspNet.Execution
 
                 var inputArgs = this.GatherInputArguments(targetDirective, appliedDirective.ArgumentValues);
 
-                var operationRequest = new QueryExecutionRequest(GraphQueryData.Empty);
+                var queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
                 var invocationContext = new DirectiveInvocationContext(
                     targetDirective,
@@ -136,7 +136,7 @@ namespace GraphQL.AspNet.Execution
                 var context = new GraphDirectiveExecutionContext(
                     schema,
                     directiveRequest,
-                    operationRequest,
+                    queryRequest,
                     scopedProvider.ServiceProvider,
                     _querySession,
                     logger: logger,

--- a/src/graphql-aspnet/Execution/GraphDirectiveRequest.cs
+++ b/src/graphql-aspnet/Execution/GraphDirectiveRequest.cs
@@ -26,7 +26,7 @@ namespace GraphQL.AspNet.Execution
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphDirectiveRequest" /> class.
         /// </summary>
-        /// <param name="operationRequest">The operation request governing
+        /// <param name="queryRequest">The query request governing
         /// this execution directive invocation.</param>
         /// <param name="invocationContext">The context detailing the specifics
         /// of what directive needs to be processed to fulfill this request.</param>
@@ -34,13 +34,13 @@ namespace GraphQL.AspNet.Execution
         /// is being processed through.</param>
         /// <param name="targetData">The real data object that is the target of this request.</param>
         public GraphDirectiveRequest(
-            IQueryExecutionRequest operationRequest,
+            IQueryExecutionRequest queryRequest,
             IDirectiveInvocationContext invocationContext,
             DirectiveInvocationPhase invocationPhase,
             object targetData)
             : this(invocationContext, invocationPhase, targetData)
         {
-            this.OperationRequest = Validation.ThrowIfNullOrReturn(operationRequest, nameof(operationRequest));
+            this.QueryRequest = Validation.ThrowIfNullOrReturn(queryRequest, nameof(queryRequest));
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace GraphQL.AspNet.Execution
             this.InvocationContext = Validation.ThrowIfNullOrReturn(invocationContext, nameof(invocationContext));
             this.DirectivePhase = invocationPhase;
             this.DirectiveTarget = targetData;
-            this.OperationRequest = null;
+            this.QueryRequest = null;
         }
 
         /// <inheritdoc />
@@ -82,6 +82,6 @@ namespace GraphQL.AspNet.Execution
         public IDirective Directive => this.InvocationContext.Directive;
 
         /// <inheritdoc />
-        public IQueryExecutionRequest OperationRequest { get; }
+        public IQueryExecutionRequest QueryRequest { get; }
     }
 }

--- a/src/graphql-aspnet/Execution/GraphFieldRequest.cs
+++ b/src/graphql-aspnet/Execution/GraphFieldRequest.cs
@@ -28,7 +28,7 @@ namespace GraphQL.AspNet.Execution
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphFieldRequest" /> class.
         /// </summary>
-        /// <param name="parentOperationRequest">The original operation request from which ths field
+        /// <param name="parentQueryRequest">The original request from which ths field
         /// request was generated.</param>
         /// <param name="invocationContext">The invocation context that defines how hte field
         /// should be processed according to the query plan.</param>
@@ -36,16 +36,16 @@ namespace GraphQL.AspNet.Execution
         /// the graph items referenced by said input data.</param>
         /// <param name="origin">The place in a source document where this request appeared.</param>
         public GraphFieldRequest(
-            IQueryExecutionRequest parentOperationRequest,
+            IQueryExecutionRequest parentQueryRequest,
             IGraphFieldInvocationContext invocationContext,
             FieldDataItemContainer dataSource,
             SourceOrigin origin = default)
         {
-            this.OperationRequest = Validation.ThrowIfNullOrReturn(parentOperationRequest, nameof(parentOperationRequest));
+            this.QueryRequest = Validation.ThrowIfNullOrReturn(parentQueryRequest, nameof(parentQueryRequest));
             this.Id = Guid.NewGuid();
             this.InvocationContext = Validation.ThrowIfNullOrReturn(invocationContext, nameof(invocationContext));
             this.Data = dataSource;
-            this.Items = parentOperationRequest.Items;
+            this.Items = parentQueryRequest.Items;
 
             // this may be different than the source indicated by teh parent operation request
             // do to child item resolution on arrays
@@ -53,7 +53,7 @@ namespace GraphQL.AspNet.Execution
         }
 
         /// <inheritdoc />
-        public IQueryExecutionRequest OperationRequest { get; }
+        public IQueryExecutionRequest QueryRequest { get; }
 
         /// <inheritdoc />
         public Guid Id { get; }

--- a/src/graphql-aspnet/Execution/QueryExecutionResult.cs
+++ b/src/graphql-aspnet/Execution/QueryExecutionResult.cs
@@ -26,7 +26,7 @@ namespace GraphQL.AspNet.Execution
         /// </summary>
         /// <param name="errorMessages">The set of messages to create a result from.</param>
         /// <param name="queryData">The original, raw query data.</param>
-        /// <returns>GraphOperationResult.</returns>
+        /// <returns>QueryExecutionResult.</returns>
         public static QueryExecutionResult FromErrorMessages(IGraphMessageCollection errorMessages, GraphQueryData queryData = null)
         {
             Validation.ThrowIfNull(errorMessages, nameof(errorMessages));

--- a/src/graphql-aspnet/Interfaces/Engine/IGraphQLRuntime.cs
+++ b/src/graphql-aspnet/Interfaces/Engine/IGraphQLRuntime.cs
@@ -42,7 +42,7 @@ namespace GraphQL.AspNet.Interfaces.Engine
         /// </summary>
         /// <param name="context">The execution context to process.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IGraphOperationResult&gt;.</returns>
+        /// <returns>Task&lt;IQueryExecutionResult&gt;.</returns>
         Task<IQueryExecutionResult> ExecuteRequestAsync(
             QueryExecutionContext context,
             CancellationToken cancelToken = default);
@@ -59,7 +59,7 @@ namespace GraphQL.AspNet.Interfaces.Engine
         /// <param name="session">The query session governing the execution of a query. A new
         /// one will be generated if not supplied.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IGraphOperationResult&gt;.</returns>
+        /// <returns>Task&lt;IQueryExecutionResult&gt;.</returns>
         Task<IQueryExecutionResult> ExecuteRequestAsync(
             IServiceProvider serviceProvider,
             IQueryExecutionRequest request,
@@ -79,7 +79,7 @@ namespace GraphQL.AspNet.Interfaces.Engine
         /// <param name="enableMetrics">if set to <c>true</c> a metrics package will be created using the default
         /// metrics package factory for the runtime.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IGraphOperationResult&gt;.</returns>
+        /// <returns>Task&lt;IQueryExecutionResult&gt;.</returns>
         Task<IQueryExecutionResult> ExecuteRequestAsync(
             IServiceProvider serviceProvider,
             IQueryExecutionRequest request,
@@ -94,7 +94,7 @@ namespace GraphQL.AspNet.Interfaces.Engine
         /// graph objects.</param>
         /// <param name="request">The primary data request.</param>
         /// <param name="cancelToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>Task&lt;IGraphOperationResult&gt;.</returns>
+        /// <returns>Task&lt;IQueryExecutionResult&gt;.</returns>
         Task<IQueryExecutionResult> ExecuteRequestAsync(
             IServiceProvider serviceProvider,
             IQueryExecutionRequest request,

--- a/src/graphql-aspnet/Interfaces/Execution/IGraphDirectiveRequest.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/IGraphDirectiveRequest.cs
@@ -25,7 +25,7 @@ namespace GraphQL.AspNet.Interfaces.Execution
         /// This value will be null during the execution of Type System Directives at startup.
         /// </remarks>
         /// <value>The operation request.</value>
-        IQueryExecutionRequest OperationRequest { get; }
+        IQueryExecutionRequest QueryRequest { get; }
 
         /// <summary>
         /// Gets the invocation context containing the specific details

--- a/src/graphql-aspnet/Interfaces/Execution/IGraphFieldRequest.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/IGraphFieldRequest.cs
@@ -30,7 +30,7 @@ namespace GraphQL.AspNet.Interfaces.Execution
         /// Gets the original operation request governing this field request.
         /// </summary>
         /// <value>The operation request.</value>
-        public IQueryExecutionRequest OperationRequest { get; }
+        public IQueryExecutionRequest QueryRequest { get; }
 
         /// <summary>
         /// Gets the invocation context, an object containing details about

--- a/src/graphql-aspnet/Interfaces/Execution/IGraphQLMiddlewareExecutionContext.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/IGraphQLMiddlewareExecutionContext.cs
@@ -46,7 +46,7 @@ namespace GraphQL.AspNet.Interfaces.Execution
         /// generated from an HTTP request.
         /// </summary>
         /// <value>The top level request.</value>
-        IQueryExecutionRequest OperationRequest { get; }
+        IQueryExecutionRequest QueryRequest { get; }
 
         /// <summary>
         /// Gets the service provider assigned to this context to use for any required

--- a/src/graphql-aspnet/Logging/GeneralEvents/RequestCancelledLogEntry.cs
+++ b/src/graphql-aspnet/Logging/GeneralEvents/RequestCancelledLogEntry.cs
@@ -25,26 +25,26 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         public RequestCancelledLogEntry(QueryExecutionContext context)
             : base(LogEventIds.RequestCancelled)
         {
-            this.OperationRequestId = context?.OperationRequest?.Id.ToString();
+            this.QueryRequestId = context?.QueryRequest?.Id.ToString();
 
             this.TotalExecutionMs = 0;
-            if (context?.OperationRequest?.StartTimeUTC != null)
+            if (context?.QueryRequest?.StartTimeUTC != null)
             {
                 this.TotalExecutionMs = DateTimeOffset
                     .UtcNow
-                    .Subtract(context.OperationRequest.StartTimeUTC)
+                    .Subtract(context.QueryRequest.StartTimeUTC)
                     .TotalMilliseconds;
             }
         }
 
         /// <summary>
-        /// Gets the globally unique id of the operation request on this event.
+        /// Gets the globally unique id of the query request on this event.
         /// </summary>
         /// <value>The unique operation request id.</value>
-        public string OperationRequestId
+        public string QueryRequestId
         {
-            get => this.GetProperty<string>(LogPropertyNames.OPERATION_REQUEST_ID);
-            private set => this.SetProperty(LogPropertyNames.OPERATION_REQUEST_ID, value);
+            get => this.GetProperty<string>(LogPropertyNames.QUERY_REQUEST_ID);
+            private set => this.SetProperty(LogPropertyNames.QUERY_REQUEST_ID, value);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            var idTruncated = this.OperationRequestId?.Length > 8 ? this.OperationRequestId.Substring(0, 8) : this.OperationRequestId;
+            var idTruncated = this.QueryRequestId?.Length > 8 ? this.QueryRequestId.Substring(0, 8) : this.QueryRequestId;
             return $"Request Cancelled | Id: {idTruncated}";
         }
     }

--- a/src/graphql-aspnet/Logging/GeneralEvents/RequestCompletedLogEntry.cs
+++ b/src/graphql-aspnet/Logging/GeneralEvents/RequestCompletedLogEntry.cs
@@ -26,28 +26,28 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         public RequestCompletedLogEntry(QueryExecutionContext context)
             : base(LogEventIds.RequestCompleted)
         {
-            this.OperationRequestId = context?.OperationRequest?.Id.ToString();
+            this.QueryRequestId = context?.QueryRequest?.Id.ToString();
             this.ResultHasErrors = context?.Messages?.Severity.IsCritical();
             this.ResultHasData = context?.Result == null ? null : context.Result.Data != null;
 
             this.TotalExecutionMs = 0;
-            if (context?.OperationRequest?.StartTimeUTC != null)
+            if (context?.QueryRequest?.StartTimeUTC != null)
             {
                 this.TotalExecutionMs = DateTimeOffset
                     .UtcNow
-                    .Subtract(context.OperationRequest.StartTimeUTC)
+                    .Subtract(context.QueryRequest.StartTimeUTC)
                     .TotalMilliseconds;
             }
         }
 
         /// <summary>
-        /// Gets the globally unique id of the operation request on this event.
+        /// Gets the globally unique id of the query request on this event.
         /// </summary>
         /// <value>The unique operation request id.</value>
-        public string OperationRequestId
+        public string QueryRequestId
         {
-            get => this.GetProperty<string>(LogPropertyNames.OPERATION_REQUEST_ID);
-            private set => this.SetProperty(LogPropertyNames.OPERATION_REQUEST_ID, value);
+            get => this.GetProperty<string>(LogPropertyNames.QUERY_REQUEST_ID);
+            private set => this.SetProperty(LogPropertyNames.QUERY_REQUEST_ID, value);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            var idTruncated = this.OperationRequestId?.Length > 8 ? this.OperationRequestId.Substring(0, 8) : this.OperationRequestId;
+            var idTruncated = this.QueryRequestId?.Length > 8 ? this.QueryRequestId.Substring(0, 8) : this.QueryRequestId;
             return $"Request Completed | Id: {idTruncated}, Has Data: {this.ResultHasData}, Has Errors: {this.ResultHasErrors}";
         }
     }

--- a/src/graphql-aspnet/Logging/GeneralEvents/RequestReceivedLogEntry.cs
+++ b/src/graphql-aspnet/Logging/GeneralEvents/RequestReceivedLogEntry.cs
@@ -24,10 +24,10 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         public RequestReceivedLogEntry(QueryExecutionContext context)
             : base(LogEventIds.RequestReceived)
         {
-            this.OperationRequestId = context?.OperationRequest?.Id.ToString();
+            this.QueryRequestId = context?.QueryRequest?.Id.ToString();
             this.Username = context?.SecurityContext?.DefaultUser?.Identity?.Name;
-            this.QueryOperationName = context?.OperationRequest?.OperationName;
-            this.QueryText = context?.OperationRequest?.QueryText;
+            this.QueryOperationName = context?.QueryRequest?.OperationName;
+            this.QueryText = context?.QueryRequest?.QueryText;
         }
 
         /// <summary>
@@ -41,13 +41,13 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         }
 
         /// <summary>
-        /// Gets the globally unique id of the operation request on this event.
+        /// Gets the globally unique id of the query request on this event.
         /// </summary>
         /// <value>The unique operation request id.</value>
-        public string OperationRequestId
+        public string QueryRequestId
         {
-            get => this.GetProperty<string>(LogPropertyNames.OPERATION_REQUEST_ID);
-            private set => this.SetProperty(LogPropertyNames.OPERATION_REQUEST_ID, value);
+            get => this.GetProperty<string>(LogPropertyNames.QUERY_REQUEST_ID);
+            private set => this.SetProperty(LogPropertyNames.QUERY_REQUEST_ID, value);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            var idTruncated = (this.OperationRequestId?.Length ?? 0) > 8 ? this.OperationRequestId.Substring(0, 8) : string.Empty;
+            var idTruncated = (this.QueryRequestId?.Length ?? 0) > 8 ? this.QueryRequestId.Substring(0, 8) : string.Empty;
             return $"Graph Query Received | User: {this.Username ?? "{anon}"},  Id: {idTruncated}, Query Length: {this.QueryText?.Length ?? 0}";
         }
     }

--- a/src/graphql-aspnet/Logging/GeneralEvents/RequestTimedOutLogEntry.cs
+++ b/src/graphql-aspnet/Logging/GeneralEvents/RequestTimedOutLogEntry.cs
@@ -25,27 +25,27 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         public RequestTimedOutLogEntry(QueryExecutionContext context)
             : base(LogEventIds.RequestTimeout)
         {
-            var startDate = context?.OperationRequest?.StartTimeUTC ?? DateTimeOffset.MinValue;
-            this.OperationRequestId = context?.OperationRequest?.Id.ToString();
+            var startDate = context?.QueryRequest?.StartTimeUTC ?? DateTimeOffset.MinValue;
+            this.QueryRequestId = context?.QueryRequest?.Id.ToString();
 
             this.TotalExecutionMs = 0;
-            if (context?.OperationRequest?.StartTimeUTC != null)
+            if (context?.QueryRequest?.StartTimeUTC != null)
             {
                 this.TotalExecutionMs = DateTimeOffset
                     .UtcNow
-                    .Subtract(context.OperationRequest.StartTimeUTC)
+                    .Subtract(context.QueryRequest.StartTimeUTC)
                     .TotalMilliseconds;
             }
         }
 
         /// <summary>
-        /// Gets the globally unique id of the operation request on this event.
+        /// Gets the globally unique id of the query request on this event.
         /// </summary>
         /// <value>The unique operation request id.</value>
-        public string OperationRequestId
+        public string QueryRequestId
         {
-            get => this.GetProperty<string>(LogPropertyNames.OPERATION_REQUEST_ID);
-            private set => this.SetProperty(LogPropertyNames.OPERATION_REQUEST_ID, value);
+            get => this.GetProperty<string>(LogPropertyNames.QUERY_REQUEST_ID);
+            private set => this.SetProperty(LogPropertyNames.QUERY_REQUEST_ID, value);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace GraphQL.AspNet.Logging.GeneralEvents
         /// <returns>A <see cref="string" /> that represents this instance.</returns>
         public override string ToString()
         {
-            var idTruncated = this.OperationRequestId?.Length > 8 ? this.OperationRequestId.Substring(0, 8) : this.OperationRequestId;
+            var idTruncated = this.QueryRequestId?.Length > 8 ? this.QueryRequestId.Substring(0, 8) : this.QueryRequestId;
             return $"Request Timed Out | Id: {idTruncated} | Total Time (ms): {this.TotalExecutionMs}";
         }
     }

--- a/src/graphql-aspnet/Logging/LogPropertyNames.cs
+++ b/src/graphql-aspnet/Logging/LogPropertyNames.cs
@@ -120,7 +120,7 @@ namespace GraphQL.AspNet.Logging
         /// <summary>
         /// The unique id assigned to an individual operation request.
         /// </summary>
-        public const string OPERATION_REQUEST_ID = "operationRequestId";
+        public const string QUERY_REQUEST_ID = "queryRequestId";
 
         /// <summary>
         /// The unique id assigned to an individual pipele/field resolution request.

--- a/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/FieldExecution/Components/ProcessChildFieldsMiddleware.cs
@@ -335,7 +335,7 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
                         child);
 
                     var request = new GraphFieldRequest(
-                        parentContext.Request.OperationRequest,
+                        parentContext.Request.QueryRequest,
                         childInvocationContext,
                         dataSource,
                         child.Origin);
@@ -386,7 +386,7 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
                     sourceItemList);
 
                 var request = new GraphFieldRequest(
-                    parentContext.Request.OperationRequest,
+                    parentContext.Request.QueryRequest,
                     childInvocationContext,
                     dataSource,
                     batchOrigin);

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
@@ -173,7 +173,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 targetDirective,
                 directiveDocumentPart);
 
-            var parentRequest = queryContext.OperationRequest;
+            var parentRequest = queryContext.QueryRequest;
 
             var invocationContext = new DirectiveInvocationContext(
                 targetDirective,
@@ -182,7 +182,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 inputArgs);
 
             var request = new GraphDirectiveRequest(
-                queryContext.OperationRequest,
+                queryContext.QueryRequest,
                 invocationContext,
                 DirectiveInvocationPhase.QueryDocumentExecution,
                 targetDocumentPart);

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/AssignQueryOperationMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/AssignQueryOperationMiddleware.cs
@@ -31,7 +31,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 }
                 else
                 {
-                    var operationToExecute = context.OperationRequest.OperationName?.Trim() ?? string.Empty;
+                    var operationToExecute = context.QueryRequest.OperationName?.Trim() ?? string.Empty;
                     var operation = context.QueryDocument.Operations.RetrieveOperation(operationToExecute);
                     context.Operation = operation;
                     if (context.Operation == null)

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/CacheQueryExecutionPlanMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/CacheQueryExecutionPlanMiddleware.cs
@@ -59,11 +59,11 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
         {
             bool planFound = false;
             string key = null;
-            if (_keyManager != null && _cacheProvider != null && context.OperationRequest?.QueryText != null)
+            if (_keyManager != null && _cacheProvider != null && context.QueryRequest?.QueryText != null)
             {
                 key = _keyManager.CreateKey<TSchema>(
-                    context.OperationRequest.QueryText,
-                    context.OperationRequest.OperationName);
+                    context.QueryRequest.QueryText,
+                    context.QueryRequest.OperationName);
 
                 planFound = await _cacheProvider.TryGetPlanAsync(key, out var queryPlan).ConfigureAwait(false);
                 if (planFound)

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ExecuteQueryOperationMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ExecuteQueryOperationMiddleware.cs
@@ -148,7 +148,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 var sourceData = new FieldDataItemContainer(dataSourceValue, path, topLevelDataItem);
 
                 var fieldRequest = new GraphFieldRequest(
-                    context.OperationRequest,
+                    context.QueryRequest,
                     item.Context,
                     sourceData,
                     new SourceOrigin(item.Context.Origin.Location, path));

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
@@ -33,7 +33,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 fieldSet = this.CreateFinalDictionary(context);
             }
 
-            context.Result = new QueryExecutionResult(context.OperationRequest, context.Messages, fieldSet, context.Metrics);
+            context.Result = new QueryExecutionResult(context.QueryRequest, context.Messages, fieldSet, context.Metrics);
             context.Logger?.RequestCompleted(context);
             return next(context, cancelToken);
         }

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ParseQueryDocumentMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ParseQueryDocumentMiddleware.cs
@@ -55,8 +55,8 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 try
                 {
                     var text = ReadOnlySpan<char>.Empty;
-                    if (context.OperationRequest.QueryText != null)
-                        text = context.OperationRequest.QueryText.AsSpan();
+                    if (context.QueryRequest.QueryText != null)
+                        text = context.QueryRequest.QueryText.AsSpan();
 
                     // convert the AST into a functional document
                     // matched against the target schema

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateOperationVariableDataMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateOperationVariableDataMiddleware.cs
@@ -50,14 +50,14 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                     this.ResolveVariables(
                         context,
                         context.QueryPlan.Operation.Variables,
-                        context.OperationRequest.VariableData);
+                        context.QueryRequest.VariableData);
                 }
                 else if (context.Operation != null)
                 {
                     this.ResolveVariables(
                         context,
                         context.Operation.Variables,
-                        context.OperationRequest.VariableData);
+                        context.QueryRequest.VariableData);
                 }
             }
 

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateQueryRequestMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateQueryRequestMiddleware.cs
@@ -33,7 +33,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                     new InvalidOperationException($"The {nameof(QueryExecutionContext)} governing the execution of the pipeline was provided as null. Operation failed."));
             }
 
-            if (context.OperationRequest == null || string.IsNullOrWhiteSpace(context.OperationRequest.QueryText))
+            if (context.QueryRequest == null || string.IsNullOrWhiteSpace(context.QueryRequest.QueryText))
             {
                 // capture execution exceptions, they will relate to the internal processing
                 // of the server and should only be exposed to authorized parties (via exception details)

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/Execution/ExecutionDirectiveTestData/QueryRequestCheckDirective.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/Execution/ExecutionDirectiveTestData/QueryRequestCheckDirective.cs
@@ -14,17 +14,17 @@ namespace GraphQL.AspNet.Tests.Execution.ExecutionDirectiveTestData
     using GraphQL.AspNet.Interfaces.Controllers;
     using GraphQL.AspNet.Schemas.TypeSystem;
 
-    public class OperationRequestCheckDirective : GraphDirective
+    public class QueryRequestCheckDirective : GraphDirective
     {
         public string ExpectedQueryText { get; set; }
 
-        public bool OperationRequestReceived { get; set; }
+        public bool QueryRequestReceived { get; set; }
 
         [DirectiveLocations(DirectiveLocation.AllExecutionLocations)]
         public IGraphActionResult Execute()
         {
-            if (this.Request.OperationRequest?.QueryText == this.ExpectedQueryText)
-                this.OperationRequestReceived = true;
+            if (this.Request.QueryRequest?.QueryText == this.ExpectedQueryText)
+                this.QueryRequestReceived = true;
 
             return this.Ok();
         }

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/Execution/ExecutionDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/Execution/ExecutionDirectiveTests.cs
@@ -61,18 +61,18 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task OperationRequestIsCorrectlySetOnInvokedExecutionDirective()
+        public async Task QueryRequestIsCorrectlySetOnInvokedExecutionDirective()
         {
-            var queryText = "query  { retrieveObject @operationRequestCheck { property1 } }";
+            var queryText = "query  { retrieveObject @queryRequestCheck { property1 } }";
 
-            var directiveInstance = new OperationRequestCheckDirective();
+            var directiveInstance = new QueryRequestCheckDirective();
             directiveInstance.ExpectedQueryText = queryText;
 
             var serverBuilder = new TestServerBuilder();
             serverBuilder.AddSingleton(directiveInstance);
             serverBuilder.AddGraphController<DirectiveTestController>()
                    .AddSubscriptionServer()
-                   .AddDirective<OperationRequestCheckDirective>();
+                   .AddDirective<QueryRequestCheckDirective>();
 
             var server = serverBuilder.Build();
 
@@ -88,7 +88,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var context = builder.Build(id);
             await server.ExecuteQuery(context);
 
-            Assert.IsTrue(directiveInstance.OperationRequestReceived);
+            Assert.IsTrue(directiveInstance.QueryRequestReceived);
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/Mocks/SubscriptionContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/Mocks/SubscriptionContextBuilder.cs
@@ -70,7 +70,7 @@ namespace GraphQL.AspNet.Tests.Mocks
         /// Adds a set of variables to use in the request.
         /// </summary>
         /// <param name="jsonDocument">The json document containing the variable data.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>SubscriptionContextBuilder.</returns>
         public SubscriptionContextBuilder AddVariableData(string jsonDocument)
         {
             var variableData = JsonSerializer.Deserialize<InputVariableCollection>(jsonDocument);
@@ -82,7 +82,7 @@ namespace GraphQL.AspNet.Tests.Mocks
         /// Adds the name of the operation to be executed to this instance.
         /// </summary>
         /// <param name="operationName">Name of the operation.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>SubscriptionContextBuilder.</returns>
         public SubscriptionContextBuilder AddOperationName(string operationName)
         {
             _mockRequest.Setup(x => x.OperationName).Returns(operationName);
@@ -104,7 +104,7 @@ namespace GraphQL.AspNet.Tests.Mocks
         /// Adds the speficied query text as the query to execute.
         /// </summary>
         /// <param name="queryText">The query text.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>SubscriptionContextBuilder.</returns>
         public SubscriptionContextBuilder AddQueryText(string queryText)
         {
             _mockRequest.Setup(x => x.QueryText).Returns(queryText);
@@ -149,7 +149,7 @@ namespace GraphQL.AspNet.Tests.Mocks
 
             // updateable items about the request
             var context = new SubcriptionQueryExecutionContext(
-                this.OperationRequest,
+                this.QueryRequest,
                 _client,
                 _serviceProvider,
                 new QuerySession(),
@@ -170,9 +170,9 @@ namespace GraphQL.AspNet.Tests.Mocks
         }
 
         /// <summary>
-        /// Gets the mocked operation request as its currently defined by this builder.
+        /// Gets the mocked request as its currently defined by this builder.
         /// </summary>
         /// <value>The operation request.</value>
-        public IQueryExecutionRequest OperationRequest => _mockRequest.Object;
+        public IQueryExecutionRequest QueryRequest => _mockRequest.Object;
     }
 }

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/SubscriptionDataExecutionResultTests.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/SubscriptionDataExecutionResultTests.cs
@@ -58,11 +58,11 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols
         [Test]
         public void SingleOperationCompleted_PropCheck()
         {
-            var operationResult = new Mock<IQueryExecutionResult>();
+            var queryResult = new Mock<IQueryExecutionResult>();
 
-            var result = SubscriptionQueryExecutionResult<GraphSchema>.SingleOperationCompleted("abc", operationResult.Object);
+            var result = SubscriptionQueryExecutionResult<GraphSchema>.SingleOperationCompleted("abc", queryResult.Object);
 
-            Assert.AreEqual(operationResult.Object, result.OperationResult);
+            Assert.AreEqual(queryResult.Object, result.QueryResult);
             Assert.AreEqual(SubscriptionQueryResultType.SingleQueryCompleted, result.Status);
         }
     }

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
@@ -166,10 +166,10 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
 
         private IGraphQLMiddlewareExecutionContext CreateFakeParentMiddlewareContext()
         {
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
 
-            parentContext.Setup(x => x.OperationRequest).Returns(operationRequest.Object);
+            parentContext.Setup(x => x.QueryRequest).Returns(queryRequest.Object);
             parentContext.Setup(x => x.ServiceProvider).Returns(this.ServiceProvider);
             parentContext.Setup(x => x.SecurityContext).Returns(_securityContext);
             parentContext.Setup(x => x.Metrics).Returns(null as IQueryExecutionMetrics);

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
@@ -57,7 +57,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         /// Adds a set of variables to use in the request.
         /// </summary>
         /// <param name="jsonDocument">The json document containing the variable data.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>QueryContextBuilder.</returns>
         public QueryContextBuilder AddVariableData(string jsonDocument)
         {
             var variableData = JsonSerializer.Deserialize<InputVariableCollection>(jsonDocument);
@@ -69,7 +69,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         /// Adds the name of the operation to be executed to this instance.
         /// </summary>
         /// <param name="operationName">Name of the operation.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>QueryContextBuilder.</returns>
         public QueryContextBuilder AddOperationName(string operationName)
         {
             _mockRequest.Setup(x => x.OperationName).Returns(operationName);
@@ -91,7 +91,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         /// Adds the speficied query text as the query to execute.
         /// </summary>
         /// <param name="queryText">The query text.</param>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>QueryContextBuilder.</returns>
         public QueryContextBuilder AddQueryText(string queryText)
         {
             _mockRequest.Setup(x => x.QueryText).Returns(queryText);
@@ -150,7 +150,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
 
             // updateable items about the request
             var context = new QueryExecutionContext(
-                this.OperationRequest,
+                this.QueryRequest,
                 _serviceProvider,
                 new QuerySession(),
                 securityContext: _userSecurityContext,
@@ -169,9 +169,9 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         }
 
         /// <summary>
-        /// Gets the mocked operation request as its currently defined by this builder.
+        /// Gets the mocked request as its currently defined by this builder.
         /// </summary>
-        /// <value>The operation request.</value>
-        public IQueryExecutionRequest OperationRequest => _mockRequest.Object;
+        /// <value>The request.</value>
+        public IQueryExecutionRequest QueryRequest => _mockRequest.Object;
     }
 }

--- a/src/unit-tests/graphql-aspnet-testframework/TestServer.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/TestServer.cs
@@ -247,15 +247,15 @@ namespace GraphQL.AspNet.Tests.Framework
             var messages = new GraphMessageCollection();
             var metaData = new MetaDataCollection();
 
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var fieldInvocationContext = new Mock<IGraphFieldInvocationContext>();
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
             var graphFieldRequest = new Mock<IGraphFieldRequest>();
             var fieldDocumentPart = new Mock<IFieldDocumentPart>();
 
-            operationRequest.Setup(x => x.Items).Returns(metaData);
+            queryRequest.Setup(x => x.Items).Returns(metaData);
 
-            parentContext.Setup(x => x.OperationRequest).Returns(operationRequest.Object);
+            parentContext.Setup(x => x.QueryRequest).Returns(queryRequest.Object);
             parentContext.Setup(x => x.ServiceProvider).Returns(this.ServiceProvider);
             parentContext.Setup(x => x.SecurityContext).Returns(this.SecurityContext);
             parentContext.Setup(x => x.Metrics).Returns(null as IQueryExecutionMetrics);
@@ -406,7 +406,7 @@ namespace GraphQL.AspNet.Tests.Framework
 
             var targetDirective = server.Schema.KnownTypes.FindDirective(typeof(TDirective));
 
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var directiveRequest = new Mock<IGraphDirectiveRequest>();
             var invocationContext = new Mock<IDirectiveInvocationContext>();
             var argCollection = new InputArgumentCollection();
@@ -440,7 +440,7 @@ namespace GraphQL.AspNet.Tests.Framework
             var context = new GraphDirectiveExecutionContext(
                 server.Schema,
                 directiveRequest.Object,
-                operationRequest.Object,
+                queryRequest.Object,
                 server.ServiceProvider,
                 new QuerySession());
 
@@ -451,7 +451,7 @@ namespace GraphQL.AspNet.Tests.Framework
         /// Creates a new mocked query context to which standard parameters (query text, variables etc.) can be configured
         /// and then submitted to the top level query execution pipeline.
         /// </summary>
-        /// <returns>MockOperationRequest.</returns>
+        /// <returns>QueryContextBuilder.</returns>
         public QueryContextBuilder CreateQueryContextBuilder()
         {
             return new QueryContextBuilder(this.ServiceProvider, _userSecurityContext);

--- a/src/unit-tests/graphql-aspnet-tests/Controllers/GraphQueryProcessorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Controllers/GraphQueryProcessorTests.cs
@@ -44,8 +44,8 @@ namespace GraphQL.AspNet.Tests.Controllers
             var httpContext = context;
             var response = httpContext.Response;
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            var result = new GraphQLHttpResponseWriter(operationResult.Object, null, false, exposeExceptions);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            var result = new GraphQLHttpResponseWriter(queryResult.Object, null, false, exposeExceptions);
 
             await result.WriteResultAsync(httpContext);
 

--- a/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
@@ -50,7 +50,7 @@ namespace GraphQL.AspNet.Tests.Directives
         private Mock<IInputArgumentCollection> _argCollection;
         private Mock<IInputValue> _argValue;
         private string _reason = null;
-        private QueryExecutionRequest _operationRequest;
+        private QueryExecutionRequest _queryRequest;
         private DirectiveInvocationContext _invocationContext;
         private DirectiveLocation _directiveLocation;
         private IServiceProvider _provider;
@@ -104,7 +104,7 @@ namespace GraphQL.AspNet.Tests.Directives
             _argCollection.Setup(x => x.Merge(It.IsAny<IResolvedVariableCollection>()))
                 .Returns(executionArgs);
 
-            _operationRequest = new QueryExecutionRequest(GraphQueryData.Empty);
+            _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
             _invocationContext = new DirectiveInvocationContext(
                 _directive,
@@ -120,7 +120,7 @@ namespace GraphQL.AspNet.Tests.Directives
             var context = new GraphDirectiveExecutionContext(
                 _schema,
                 directiveRequest,
-                _operationRequest,
+                _queryRequest,
                 _scopedProvider.ServiceProvider,
                 new QuerySession(),
                 logger: _logger.Object);

--- a/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
@@ -44,7 +44,7 @@ namespace GraphQL.AspNet.Tests.Directives
         private Mock<IInputArgumentCollection> _argCollection;
         private Mock<IInputValue> _argValue;
         private string _url = null;
-        private QueryExecutionRequest _operationRequest;
+        private QueryExecutionRequest _queryRequest;
         private DirectiveInvocationContext _invocationContext;
         private DirectiveLocation _directiveLocation;
         private IServiceProvider _provider;
@@ -97,7 +97,7 @@ namespace GraphQL.AspNet.Tests.Directives
             _argCollection.Setup(x => x.Merge(It.IsAny<IResolvedVariableCollection>()))
                 .Returns(executionArgs);
 
-            _operationRequest = new QueryExecutionRequest(GraphQueryData.Empty);
+            _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
             _invocationContext = new DirectiveInvocationContext(
                 _directive,
@@ -113,7 +113,7 @@ namespace GraphQL.AspNet.Tests.Directives
             var context = new GraphDirectiveExecutionContext(
                 _schema,
                 directiveRequest,
-                _operationRequest,
+                _queryRequest,
                 _scopedProvider.ServiceProvider,
                 new QuerySession(),
                 logger: _logger.Object);

--- a/src/unit-tests/graphql-aspnet-tests/Engine/DefaultEventLoggerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/DefaultEventLoggerTests.cs
@@ -589,7 +589,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var failedAuthResult = new SchemaItemSecurityChallengeContext(
@@ -611,7 +611,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var nonFailResult = new SchemaItemSecurityChallengeContext(
@@ -633,7 +633,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var nonResult = new SchemaItemSecurityChallengeContext(
@@ -655,7 +655,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var nonResult = new SchemaItemSecurityChallengeContext(
@@ -677,7 +677,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var nonResult = new SchemaItemSecurityChallengeContext(
@@ -710,7 +710,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var authResult = new Mock<IAuthenticationResult>();
@@ -730,7 +730,7 @@ namespace GraphQL.AspNet.Tests.Engine
             var context = new Mock<IGraphQLMiddlewareExecutionContext>();
             var secRequest = new Mock<ISchemaItemSecurityRequest>();
             context.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
-            context.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            context.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             context.Setup(x => x.Session).Returns(new Mock<IQuerySession>().Object);
 
             var authResult = new Mock<IAuthenticationResult>();

--- a/src/unit-tests/graphql-aspnet-tests/Execution/ContextTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/ContextTests.cs
@@ -28,14 +28,14 @@ namespace GraphQL.AspNet.Tests.Execution
         {
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
 
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var variableData = new Mock<IResolvedVariableCollection>();
             var serviceProvider = new Mock<IServiceProvider>();
             var logger = new Mock<IGraphEventLogger>();
             var metrics = new Mock<IQueryExecutionMetrics>();
             var securityContext = new Mock<IUserSecurityContext>();
 
-            parentContext.Setup(x => x.OperationRequest).Returns(operationRequest.Object);
+            parentContext.Setup(x => x.QueryRequest).Returns(queryRequest.Object);
             parentContext.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
             parentContext.Setup(x => x.SecurityContext).Returns(securityContext.Object);
             parentContext.Setup(x => x.Metrics).Returns(metrics.Object);
@@ -51,7 +51,7 @@ namespace GraphQL.AspNet.Tests.Execution
                 variableData.Object,
                 sourceFieldCollection);
 
-            Assert.AreEqual(operationRequest.Object, context.OperationRequest);
+            Assert.AreEqual(queryRequest.Object, context.QueryRequest);
             Assert.AreEqual(variableData.Object, context.VariableData);
             Assert.AreEqual(sourceFieldCollection, context.DefaultFieldSources);
             Assert.AreEqual(fieldRequest.Object, context.Request);
@@ -67,7 +67,7 @@ namespace GraphQL.AspNet.Tests.Execution
         {
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
 
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var variableData = new Mock<IResolvedVariableCollection>();
             var serviceProvider = new Mock<IServiceProvider>();
             var logger = new Mock<IGraphEventLogger>();
@@ -81,7 +81,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var items = new MetaDataCollection();
 
             var context = new QueryExecutionContext(
-                operationRequest.Object,
+                queryRequest.Object,
                 serviceProvider.Object,
                 session,
                 items,
@@ -89,7 +89,7 @@ namespace GraphQL.AspNet.Tests.Execution
                 metrics.Object,
                 logger.Object);
 
-            Assert.AreEqual(operationRequest.Object, context.OperationRequest);
+            Assert.AreEqual(queryRequest.Object, context.QueryRequest);
             Assert.AreEqual(sourceFieldCollection, context.DefaultFieldSources);
             Assert.AreEqual(serviceProvider.Object, context.ServiceProvider);
             Assert.AreEqual(logger.Object, context.Logger);
@@ -107,7 +107,7 @@ namespace GraphQL.AspNet.Tests.Execution
         {
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
 
-            var operationRequest = new Mock<IQueryExecutionRequest>();
+            var queryRequest = new Mock<IQueryExecutionRequest>();
             var variableData = new Mock<IResolvedVariableCollection>();
             var serviceProvider = new Mock<IServiceProvider>();
             var logger = new Mock<IGraphEventLogger>();
@@ -115,7 +115,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var securityContext = new Mock<IUserSecurityContext>();
             var schema = new GraphSchema();
 
-            parentContext.Setup(x => x.OperationRequest).Returns(operationRequest.Object);
+            parentContext.Setup(x => x.QueryRequest).Returns(queryRequest.Object);
             parentContext.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
             parentContext.Setup(x => x.SecurityContext).Returns(securityContext.Object);
             parentContext.Setup(x => x.Metrics).Returns(metrics.Object);
@@ -132,7 +132,7 @@ namespace GraphQL.AspNet.Tests.Execution
                 directiveRequest.Object,
                 args.Object);
 
-            Assert.AreEqual(operationRequest.Object, context.OperationRequest);
+            Assert.AreEqual(queryRequest.Object, context.QueryRequest);
             Assert.AreEqual(directiveRequest.Object, context.Request);
             Assert.AreEqual(serviceProvider.Object, context.ServiceProvider);
             Assert.AreEqual(logger.Object, context.Logger);

--- a/src/unit-tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
@@ -266,7 +266,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var mockResult = new Mock<IQueryExecutionResult>();
             mockResult.Setup(x => x.Data).Returns(dic);
             mockResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            mockResult.Setup(x => x.Request).Returns(queryBuilder.OperationRequest);
+            mockResult.Setup(x => x.Request).Returns(queryBuilder.QueryRequest);
 
             var writer = new DefaultQueryResponseWriter<GraphSchema>(server.Schema);
             var result = await this.WriteResponse(writer, mockResult.Object);

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Response/ResponseWriterTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Response/ResponseWriterTests.cs
@@ -40,11 +40,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -71,11 +71,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -102,11 +102,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -133,11 +133,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -164,11 +164,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -195,11 +195,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -226,11 +226,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -257,11 +257,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -288,11 +288,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -319,11 +319,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -350,11 +350,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -381,11 +381,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Response/ResponseWriterTests_NET60.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Response/ResponseWriterTests_NET60.cs
@@ -41,11 +41,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -72,11 +72,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -103,11 +103,11 @@ namespace GraphQL.AspNet.Tests.Execution.Response
             var fieldSet = new Mock<IQueryResponseFieldSet>();
             fieldSet.Setup(x => x.Fields).Returns(data);
 
-            var operationResult = new Mock<IQueryExecutionResult>();
-            operationResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
-            operationResult.Setup(x => x.Data).Returns(fieldSet.Object);
+            var queryResult = new Mock<IQueryExecutionResult>();
+            queryResult.Setup(x => x.Messages).Returns(new GraphMessageCollection());
+            queryResult.Setup(x => x.Data).Returns(fieldSet.Object);
 
-            await writer.WriteAsync(stream, operationResult.Object);
+            await writer.WriteAsync(stream, queryResult.Object);
 
             stream.Seek(0, SeekOrigin.Begin);
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/SortedFieldExecutionContextListTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/SortedFieldExecutionContextListTests.cs
@@ -24,7 +24,7 @@ namespace GraphQL.AspNet.Tests.Execution
         private GraphFieldExecutionContext CreateFakeContext()
         {
             var parentContext = new Mock<IGraphQLMiddlewareExecutionContext>();
-            parentContext.Setup(x => x.OperationRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
+            parentContext.Setup(x => x.QueryRequest).Returns(new Mock<IQueryExecutionRequest>().Object);
             parentContext.Setup(x => x.ServiceProvider).Returns(new Mock<IServiceProvider>().Object);
             parentContext.Setup(x => x.Session).Returns(new QuerySession());
 

--- a/src/unit-tests/graphql-aspnet-tests/Logging/GeneralEventLogEntryPropertyChecks.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Logging/GeneralEventLogEntryPropertyChecks.cs
@@ -131,13 +131,13 @@ namespace GraphQL.AspNet.Tests.Logging
 
             var builder = server.CreateQueryContextBuilder();
             builder.AddQueryText("{ testField }");
-            var request = builder.OperationRequest;
+            var request = builder.QueryRequest;
             var context = builder.Build();
 
             var entry = new RequestReceivedLogEntry(context);
 
             Assert.AreEqual(LogEventIds.RequestReceived.Id, entry.EventId);
-            Assert.AreEqual(request.Id.ToString(), entry.OperationRequestId);
+            Assert.AreEqual(request.Id.ToString(), entry.QueryRequestId);
             Assert.AreEqual("fakeUserName", entry.Username);
             Assert.AreEqual(request.OperationName, entry.QueryOperationName);
             Assert.AreEqual("{ testField }", entry.QueryText);
@@ -153,7 +153,7 @@ namespace GraphQL.AspNet.Tests.Logging
 
             var builder = server.CreateQueryContextBuilder();
             builder.AddQueryText("{ testField }");
-            var request = builder.OperationRequest;
+            var request = builder.QueryRequest;
             var context = builder.Build();
 
             var mock = new Mock<IQueryExecutionResult>();
@@ -166,7 +166,7 @@ namespace GraphQL.AspNet.Tests.Logging
             var entry = new RequestCompletedLogEntry(context);
 
             Assert.AreEqual(LogEventIds.RequestCompleted.Id, entry.EventId);
-            Assert.AreEqual(request.Id.ToString(), entry.OperationRequestId);
+            Assert.AreEqual(request.Id.ToString(), entry.QueryRequestId);
             Assert.AreEqual(false, entry.ResultHasErrors);
             Assert.AreEqual(true, entry.ResultHasData);
             Assert.IsNotNull(entry.ToString());


### PR DESCRIPTION
* Removed references to `OperationRequest`, renamed to `QueryRequest`
* Removed references to `OperationResult`, renamed to `QueryResult`