### PR TITLE
Issue with Retreiving a Query Plan from Cache

### DIFF
--- a/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanCacheProvider.cs
+++ b/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanCacheProvider.cs
@@ -60,10 +60,10 @@ namespace GraphQL.AspNet.Engine
         }
 
         /// <inheritdoc />
-        public Task<bool> TryGetPlanAsync(string key, out IQueryExecutionPlan plan)
+        public Task<IQueryExecutionPlan> TryGetPlanAsync(string key)
         {
-            plan = _cachedPlans.Get(key) as IQueryExecutionPlan;
-            return (plan != null).AsCompletedTask();
+            var plan = _cachedPlans.Get(key) as IQueryExecutionPlan;
+            return Task.FromResult(plan as IQueryExecutionPlan);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Interfaces/Engine/IQueryExecutionPlanCacheProvider.cs
+++ b/src/graphql-aspnet/Interfaces/Engine/IQueryExecutionPlanCacheProvider.cs
@@ -21,12 +21,11 @@ namespace GraphQL.AspNet.Interfaces.Engine
     public interface IQueryExecutionPlanCacheProvider
     {
         /// <summary>
-        /// Attempts to retrieve a query plan from the cache for the given schema if it sexists.
+        /// Attempts to retrieve a query plan from the cache for the given schema if it exists.
         /// </summary>
         /// <param name="key">The unique key for the plan of a given schema.</param>
-        /// <param name="plan">The plan that was retrieved or null if it was not found.</param>
-        /// <returns><c>true</c> if the plan was successfully retrieved; otherwise, <c>false</c>.</returns>
-        Task<bool> TryGetPlanAsync(string key, out IQueryExecutionPlan plan);
+        /// <returns>Returns the query plan if it was found, otherwise null.</returns>
+        Task<IQueryExecutionPlan> TryGetPlanAsync(string key);
 
         /// <summary>
         /// Caches the plan instance for later retrieval.

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/CacheQueryExecutionPlanMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/CacheQueryExecutionPlanMiddleware.cs
@@ -65,8 +65,8 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                     context.QueryRequest.QueryText,
                     context.QueryRequest.OperationName);
 
-                planFound = await _cacheProvider.TryGetPlanAsync(key, out var queryPlan).ConfigureAwait(false);
-                if (planFound)
+                var queryPlan = await _cacheProvider.TryGetPlanAsync(key).ConfigureAwait(false);
+                if (queryPlan != null)
                 {
                     context.QueryPlan = queryPlan;
                     context.Logger?.QueryPlanCacheFetchHit<TSchema>(key);

--- a/src/unit-tests/graphql-aspnet-tests/Execution/CachedQueryPlanTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/CachedQueryPlanTests.cs
@@ -59,9 +59,7 @@ namespace GraphQL.AspNet.Tests.Execution
             Assert.IsNotNull(result.Data);
 
             var key = cacheKeyProvider.CreateKey<GraphSchema>(query, operation);
-            var found = await cacheProvider.TryGetPlanAsync(key, out var plan);
-
-            Assert.IsTrue(found);
+            var plan = await cacheProvider.TryGetPlanAsync(key);
             Assert.IsNotNull(plan);
         }
 
@@ -103,9 +101,8 @@ namespace GraphQL.AspNet.Tests.Execution
             Assert.IsNotNull(result.Data);
 
             var key = cacheKeyProvider.CreateKey<GraphSchema>(query, operation);
-            var found = await cacheProvider.TryGetPlanAsync(key, out var plan);
+            var plan = await cacheProvider.TryGetPlanAsync(key);
 
-            Assert.IsFalse(found);
             Assert.IsNull(plan);
         }
     }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/MemoryBasedQueryCacheTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/MemoryBasedQueryCacheTests.cs
@@ -36,9 +36,9 @@ namespace GraphQL.AspNet.Tests.Execution
         {
             using var cache = new DefaultQueryExecutionPlanCacheProvider();
             var hash = Guid.NewGuid().ToString("N");
-            var found = await cache.TryGetPlanAsync(hash, out var plan);
-            Assert.IsNull(plan);
-            Assert.IsFalse(found);
+
+            var foundPlan = await cache.TryGetPlanAsync(hash);
+            Assert.IsNull(foundPlan);
         }
 
         [Test]
@@ -53,8 +53,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var wasCached = await cache.TryCachePlanAsync(hash, plan);
             Assert.IsTrue(wasCached);
 
-            var found = await cache.TryGetPlanAsync(hash, out var foundPlan);
-            Assert.IsTrue(found);
+            var foundPlan = await cache.TryGetPlanAsync(hash);
             Assert.AreEqual(plan, foundPlan);
         }
 
@@ -73,8 +72,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var evicted = await cache.EvictAsync(hash);
             Assert.IsTrue(evicted);
 
-            var found = await cache.TryGetPlanAsync(hash, out var foundPlan);
-            Assert.IsFalse(found);
+            var foundPlan = await cache.TryGetPlanAsync(hash);
             Assert.IsNull(foundPlan);
         }
     }


### PR DESCRIPTION
* Fixed a bug with the method signature on `IQueryExecutionPlanCacheProvider.TryGetPlanAsync()` preventing it from becoming "asyncronizable" for implementations that may have needed it