### PR TITLE
Issues with Variables and Default Values

### DIFF
--- a/src/graphql-aspnet/Constants.cs
+++ b/src/graphql-aspnet/Constants.cs
@@ -178,7 +178,7 @@ namespace GraphQL.AspNet
             public const string INVALID_OBJECT = "INVALID_OBJECT";
             public const string DEFAULT = "UNKNOWN";
             public const string GENERAL_ERROR = "GENERAL_ERROR";
-            public const string INVALID_ARGUMENT = "INVALID_ARGUMENT";
+            public const string INVALID_ARGUMENT_VALUE = "INVALID_ARGUMENT_VALUE";
             public const string INVALID_VARIABLE_VALUE = "INVALID_VARIABLE_VALUE";
             public const string INVALID_ACTION_RESULT = "INVALID_ACTION_RESULT";
         }

--- a/src/graphql-aspnet/Constants.cs
+++ b/src/graphql-aspnet/Constants.cs
@@ -178,6 +178,7 @@ namespace GraphQL.AspNet
             public const string INVALID_OBJECT = "INVALID_OBJECT";
             public const string DEFAULT = "UNKNOWN";
             public const string GENERAL_ERROR = "GENERAL_ERROR";
+            public const string INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
             public const string INVALID_ARGUMENT_VALUE = "INVALID_ARGUMENT_VALUE";
             public const string INVALID_VARIABLE_VALUE = "INVALID_VARIABLE_VALUE";
             public const string INVALID_ACTION_RESULT = "INVALID_ACTION_RESULT";

--- a/src/graphql-aspnet/Controllers/ActionResults/InternalServerErrorGraphActionResult.cs
+++ b/src/graphql-aspnet/Controllers/ActionResults/InternalServerErrorGraphActionResult.cs
@@ -54,16 +54,17 @@ namespace GraphQL.AspNet.Controllers.ActionResults
         public InternalServerErrorGraphActionResult(IGraphFieldResolverMethod action, Exception exception)
         {
             _action = action;
+            _errorMessage = $"An unhandled exception was thrown during the execution of field '{_action?.Name ?? "-unknown-"}'.";
+
             _exception = exception;
         }
 
         /// <inheritdoc />
         public Task CompleteAsync(SchemaItemResolutionContext context)
         {
-            var message = _errorMessage ?? $"An unhandled exception was thrown during the execution of field '{_action?.Name ?? "-unknown-"}'.";
             context.Messages.Critical(
-                message,
-                Constants.ErrorCodes.UNHANDLED_EXCEPTION,
+                _errorMessage,
+                Constants.ErrorCodes.INTERNAL_SERVER_ERROR,
                 context.Request.Origin,
                 _exception);
 

--- a/src/graphql-aspnet/Controllers/GraphController_ActionResults.cs
+++ b/src/graphql-aspnet/Controllers/GraphController_ActionResults.cs
@@ -137,7 +137,7 @@ namespace GraphQL.AspNet.Controllers
         /// <returns>IGraphActionResult.</returns>
         protected virtual IGraphActionResult Unauthorized(string message = null, string errorCode = null)
         {
-            return new UnauthorizedGraphActionResult(errorCode ?? "Unauthorized", message ?? string.Empty);
+            return new UnauthorizedGraphActionResult(message, errorCode);
         }
 
         /// <summary>

--- a/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanGenerator{TSchema}.cs
+++ b/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanGenerator{TSchema}.cs
@@ -63,7 +63,6 @@ namespace GraphQL.AspNet.Engine
             if (!queryPlan.IsValid)
                 return queryPlan;
 
-
             var executableOperation = await _generator.CreateAsync(operation).ConfigureAwait(false);
             queryPlan.Operation = executableOperation;
             queryPlan.Messages.AddRange(executableOperation.Messages);

--- a/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanGenerator{TSchema}.cs
+++ b/src/graphql-aspnet/Engine/DefaultQueryExecutionPlanGenerator{TSchema}.cs
@@ -29,6 +29,7 @@ namespace GraphQL.AspNet.Engine
         private readonly ISchema _schema;
         private readonly IQueryOperationComplexityCalculator<TSchema> _complexityCalculator;
         private readonly IQueryOperationDepthCalculator<TSchema> _depthCalculator;
+        private readonly ExecutableOperationGenerator _generator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultQueryExecutionPlanGenerator{TSchema}" /> class.
@@ -46,6 +47,8 @@ namespace GraphQL.AspNet.Engine
             _schema = Validation.ThrowIfNullOrReturn(schema, nameof(schema));
             _complexityCalculator = Validation.ThrowIfNullOrReturn(complexityCalculator, nameof(complexityCalculator));
             _depthCalculator = Validation.ThrowIfNullOrReturn(depthCalculator, nameof(depthCalculator));
+
+            _generator = new ExecutableOperationGenerator(_schema);
         }
 
         /// <inheritdoc />
@@ -60,9 +63,8 @@ namespace GraphQL.AspNet.Engine
             if (!queryPlan.IsValid)
                 return queryPlan;
 
-            var generator = new ExecutableOperationGenerator(_schema);
 
-            var executableOperation = await generator.CreateAsync(operation).ConfigureAwait(false);
+            var executableOperation = await _generator.CreateAsync(operation).ConfigureAwait(false);
             queryPlan.Operation = executableOperation;
             queryPlan.Messages.AddRange(executableOperation.Messages);
 

--- a/src/graphql-aspnet/Execution/DirectiveProcessorTypeSystem.cs
+++ b/src/graphql-aspnet/Execution/DirectiveProcessorTypeSystem.cs
@@ -222,7 +222,7 @@ namespace GraphQL.AspNet.Execution
                 var resolvedValue = arguments[i];
 
                 var argValue = new ResolvedInputArgumentValue(directiveArg.Name, resolvedValue);
-                var inputArg = new InputArgument(directiveArg, argValue);
+                var inputArg = new InputArgument(directiveArg, argValue, SourceOrigin.None);
                 argCollection.Add(inputArg);
             }
 

--- a/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
@@ -9,8 +9,10 @@
 
 namespace GraphQL.AspNet.Execution
 {
+    using System;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Execution.QueryPlans.InputArguments;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.InputArguments;
     using GraphQL.AspNet.Interfaces.Execution.Variables;
@@ -88,6 +90,10 @@ namespace GraphQL.AspNet.Execution
                     // This may catch if there is a scenario where an input object
                     // has its fields constructed from nullable variables that
                     // are explicitly supplied a null value
+                    //
+                    // its also highly likely that at this stage there is no value resolver issue
+                    // just a flat out failure. As a result append a semi-helpful message to the begining
+                    // of the message.
                     var parentType = arg.Argument.Parent is IInputGraphField
                         ? "input field"
                         : "field";
@@ -98,6 +104,17 @@ namespace GraphQL.AspNet.Execution
                       Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                       arg.Origin,
                       uve);
+
+                    successful = false;
+                }
+                catch (Exception ex)
+                {
+                    var message = new GraphExecutionMessage(
+                        GraphMessageSeverity.Critical,
+                        "Invalid argument value. See exception for details.",
+                        Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
+                        arg.Origin,
+                        ex);
 
                     successful = false;
                 }

--- a/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
@@ -74,7 +74,7 @@ namespace GraphQL.AspNet.Execution
                             this.Messages.Critical(
                               $"The value supplied to argument '{argDefinition.Name}' was <null> but its expected type expression " +
                               $"is {argDefinition.TypeExpression}.",
-                              Constants.ErrorCodes.INVALID_ARGUMENT,
+                              Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                               arg.Origin);
 
                             continue;
@@ -95,7 +95,7 @@ namespace GraphQL.AspNet.Execution
                     this.Messages.Critical(
                       $"The value supplied to argument '{arg.Name}' for {parentType} '{arg.Argument.Parent.Name}' was " +
                       $"not valid for the invocation. {uve.Message}",
-                      Constants.ErrorCodes.INVALID_ARGUMENT,
+                      Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                       arg.Origin,
                       uve);
 

--- a/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
@@ -1,0 +1,64 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Execution
+{
+    using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Interfaces.Execution;
+    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.InputArguments;
+    using GraphQL.AspNet.Interfaces.Execution.Variables;
+
+    /// <summary>
+    /// An object that can generate an <see cref="IExecutionArgumentCollection"/>
+    /// from a set of arguments and variable values.
+    /// </summary>
+    public class ExecutionArgumentGenerator
+    {
+        private readonly IInputArgumentCollection _arguments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionArgumentGenerator" /> class.
+        /// </summary>
+        /// <param name="argumentCollection">The argument collection defined
+        /// on some query operation that needs to be converted to execution arguments.</param>
+        /// <param name="messages">If provided, the set of messages to be appended
+        /// to with any messages generated via the use of this instance.</param>
+        public ExecutionArgumentGenerator(
+            IInputArgumentCollection argumentCollection,
+            IGraphMessageCollection messages = null)
+        {
+            _arguments = Validation.ThrowIfNullOrReturn(argumentCollection, nameof(argumentCollection));
+            messages = messages ?? new GraphMessageCollection();
+        }
+
+        /// <summary>
+        /// Converts the
+        /// </summary>
+        /// <param name="variableData">The variable data.</param>
+        /// <returns>IExecutionArgumentCollection.</returns>
+        public bool TryConvert(IResolvedVariableCollection variableData, out IExecutionArgumentCollection generatedCollection)
+        {
+            generatedCollection = new ExecutionArgumentCollection(_arguments.Count);
+            foreach (var arg in _arguments)
+            {
+                var resolvedValue = arg.Value.Resolve(variableData);
+                generatedCollection.Add(new ExecutionArgument(arg.Argument, resolvedValue));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the set of messages generated while trying to convert the
+        /// arguments.
+        /// </summary>
+        /// <value>The messages generated.</value>
+        public IGraphMessageCollection Messages { get; }
+    }
+}

--- a/src/graphql-aspnet/Execution/GraphMessageCollection.cs
+++ b/src/graphql-aspnet/Execution/GraphMessageCollection.cs
@@ -67,9 +67,7 @@ namespace GraphQL.AspNet.Execution
                         newCapacity += 1;
 
                     do
-                    {
                         newCapacity = newCapacity * 2;
-                    }
                     while (newCount > newCapacity);
 
                     _messages.Capacity = newCapacity;

--- a/src/graphql-aspnet/Execution/QueryPlans/DocumentParts/DocumentVariable.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/DocumentParts/DocumentVariable.cs
@@ -72,5 +72,8 @@ namespace GraphQL.AspNet.Execution.QueryPlans.DocumentParts
 
         /// <inheritdoc />
         public override string Description => $"Variable: {this.Name ?? "-unknown-"}";
+
+        /// <inheritdoc />
+        public bool HasDefaultValue => this.DefaultValue != null;
     }
 }

--- a/src/graphql-aspnet/Execution/QueryPlans/ExecutableOperationGenerator.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/ExecutableOperationGenerator.cs
@@ -197,7 +197,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans
             {
                 var argResult = argGenerator.CreateInputArgument(argument);
                 if (argResult.IsValid)
-                    collection.Add(new InputArgument(argument, argResult.Argument));
+                    collection.Add(argResult.Argument);
                 else
                     _messages.Add(argResult.Message);
             }

--- a/src/graphql-aspnet/Execution/QueryPlans/ExecutableOperationGenerator.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/ExecutableOperationGenerator.cs
@@ -29,6 +29,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans
     internal class ExecutableOperationGenerator
     {
         private readonly ISchema _schema;
+        private readonly ArgumentGenerator _argumentGenerator;
         private IGraphMessageCollection _messages;
 
         /// <summary>
@@ -39,6 +40,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans
         public ExecutableOperationGenerator(ISchema schema)
         {
             _schema = Validation.ThrowIfNullOrReturn(schema, nameof(schema));
+            _argumentGenerator = new ArgumentGenerator(schema);
         }
 
         /// <summary>
@@ -183,19 +185,18 @@ namespace GraphQL.AspNet.Execution.QueryPlans
         /// Inspects the arguments supplied on the user's query document, merges them with those defaulted from the graph field itself
         /// and applies variable data as necessary to generate a single unified set of input arguments to be used when resolving a field of data.
         /// </summary>
-        /// <param name="argumentContainer">The field selection.</param>
+        /// <param name="argumentDefinitions">The set of arguments defined on a field.</param>
         /// <param name="querySuppliedArguments">The supplied argument collection parsed from the user query document.</param>
         /// <returns>Task&lt;IInputArgumentCollection&gt;.</returns>
         private IInputArgumentCollection CreateArgumentList(
-            IGraphArgumentContainer argumentContainer,
+            IGraphArgumentContainer argumentDefinitions,
             IInputArgumentCollectionDocumentPart querySuppliedArguments)
         {
-            var collection = new InputArgumentCollection(argumentContainer.Arguments.Count);
-            var argGenerator = new ArgumentGenerator(_schema, querySuppliedArguments);
+            var collection = new InputArgumentCollection(argumentDefinitions.Arguments.Count);
 
-            foreach (var argument in argumentContainer.Arguments)
+            foreach (var argumentDefinition in argumentDefinitions.Arguments)
             {
-                var argResult = argGenerator.CreateInputArgument(argument);
+                var argResult = _argumentGenerator.CreateInputArgument(querySuppliedArguments, argumentDefinition);
                 if (argResult.IsValid)
                     collection.Add(argResult.Argument);
                 else

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerationResult.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerationResult.cs
@@ -10,7 +10,6 @@
 namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
 {
     using GraphQL.AspNet.Interfaces.Execution;
-    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.InputArguments;
 
     /// <summary>
     /// The result of attempting to resolve an input argument in a query document.
@@ -18,10 +17,10 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
     internal class ArgumentGenerationResult
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArgumentGenerationResult"/> class.
+        /// Initializes a new instance of the <see cref="ArgumentGenerationResult" /> class.
         /// </summary>
         /// <param name="argument">The argument that was successfully resolved.</param>
-        public ArgumentGenerationResult(IInputValue argument)
+        public ArgumentGenerationResult(InputArgument argument)
         {
             this.Argument = argument;
         }
@@ -40,7 +39,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         /// Gets the argument that was generated.
         /// </summary>
         /// <value>The argument that was resolved.</value>
-        public IInputValue Argument { get; }
+        public InputArgument Argument { get; }
 
         /// <summary>
         /// Gets a message that was generated due to a failure in creating the argument.

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
@@ -17,6 +17,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
     using GraphQL.AspNet.Interfaces.Schema;
     using GraphQL.AspNet.Internal.Resolvers;
+    using GraphQL.AspNet.Schemas.TypeSystem;
 
     /// <summary>
     /// An object capable of taking a <see cref="DocumentSuppliedValue"/> from a document and converting it into a
@@ -50,12 +51,16 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         {
             Validation.ThrowIfNull(argument, nameof(argument));
 
-            if (!_suppliedArguments.ContainsKey(argument.Name) && argument.HasDefaultValue)
+            if (!_suppliedArguments.ContainsKey(argument.Name))
             {
-                return new ArgumentGenerationResult(
-                    new ResolvedInputArgumentValue(
-                        argument.Name,
-                        argument.DefaultValue));
+                if (argument.HasDefaultValue
+                    || argument.ArgumentModifiers.IsNotPartOfTheSchema())
+                {
+                    return new ArgumentGenerationResult(
+                        new ResolvedInputArgumentValue(
+                            argument.Name,
+                            argument.DefaultValue));
+                }
             }
 
             var coreValue = _suppliedArguments[argument.Name].Value;

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
@@ -50,16 +50,22 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         {
             Validation.ThrowIfNull(argument, nameof(argument));
 
-            if (!_suppliedArguments.ContainsKey(argument.Name))
+            if (!_suppliedArguments.ContainsKey(argument.Name) && argument.HasDefaultValue)
             {
-                return new ArgumentGenerationResult(new ResolvedInputArgumentValue(argument.Name, argument.DefaultValue));
+                return new ArgumentGenerationResult(
+                    new ResolvedInputArgumentValue(
+                        argument.Name,
+                        argument.DefaultValue));
             }
 
             var coreValue = _suppliedArguments[argument.Name].Value;
-            var resolver = _inputResolverGenerator.CreateResolver(argument.TypeExpression);
+            var resolver = _inputResolverGenerator.CreateResolver(argument);
 
             if (this.ShouldDeferResolution(coreValue))
-                return new ArgumentGenerationResult(new DeferredInputArgumentValue(coreValue, resolver));
+            {
+                return new ArgumentGenerationResult(
+                    new DeferredInputArgumentValue(coreValue, resolver));
+            }
 
             try
             {

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/ArgumentGenerator.cs
@@ -94,7 +94,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
                 var message = new GraphExecutionMessage(
                    GraphMessageSeverity.Critical,
                    svce.Message,
-                   Constants.ErrorCodes.INVALID_ARGUMENT,
+                   Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                    suppliedArgument.Origin,
                    exception: svce.InnerException);
 
@@ -105,7 +105,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
                 var message = new GraphExecutionMessage(
                     GraphMessageSeverity.Critical,
                     "Invalid argument value. See exception for details.",
-                    Constants.ErrorCodes.INVALID_ARGUMENT,
+                    Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                     suppliedArgument.Origin,
                     ex);
 

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/DeferredInputArgumentValue.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/DeferredInputArgumentValue.cs
@@ -7,6 +7,15 @@
 // License:  MIT
 // *************************************************************
 
+// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
 namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
 {
     using System.Diagnostics;
@@ -17,9 +26,9 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
     using GraphQL.AspNet.Interfaces.Execution.Variables;
 
     /// <summary>
-    /// A represenetation of a value to an input argument that has yet to be fully realized
+    /// A represenetation of a value to an argument or input field that has yet to be fully realized
     /// and will need to make use of runtime data (variables provided by on user request) to finalize its
-    /// value so that it can provide data to a resolution context.
+    /// value so that it can provide a value to a resolution context.
     /// </summary>
     [DebuggerDisplay("{_coreValue.OwnerArgument.Name}")]
     internal class DeferredInputArgumentValue : IInputValue
@@ -28,7 +37,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         private readonly IInputValueResolver _resolver;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeferredInputArgumentValue"/> class.
+        /// Initializes a new instance of the <see cref="DeferredInputArgumentValue" /> class.
         /// </summary>
         /// <param name="coreValue">The core value.</param>
         /// <param name="valueResolver">The resolver to use when rendering out a variable value for this

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/DeferredInputArgumentValue.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/DeferredInputArgumentValue.cs
@@ -7,15 +7,6 @@
 // License:  MIT
 // *************************************************************
 
-// *************************************************************
-// project:  graphql-aspnet
-// --
-// repo: https://github.com/graphql-aspnet
-// docs: https://graphql-aspnet.github.io
-// --
-// License:  MIT
-// *************************************************************
-
 namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
 {
     using System.Diagnostics;

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/InputArgument.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/InputArgument.cs
@@ -12,6 +12,7 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
     using System;
     using System.Diagnostics;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Execution.Source;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.InputArguments;
     using GraphQL.AspNet.Interfaces.Schema;
 
@@ -23,16 +24,27 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
     [Serializable]
     [DebuggerDisplay("{Name}")]
     public class InputArgument
-    {
+    { /// <summary>
+      /// Initializes a new instance of the <see cref="InputArgument" /> class.
+      /// </summary>
+      /// <param name="argument">The field argument defined in a schema.</param>
+      /// <param name="value">The value representing this field argument as its defined in a query document.</param>
+        public InputArgument(IGraphArgument argument, IInputValue value)
+            : this(argument, value, SourceOrigin.None)
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InputArgument" /> class.
         /// </summary>
         /// <param name="argument">The field argument defined in a schema.</param>
         /// <param name="value">The value representing this field argument as its defined in a query document.</param>
-        public InputArgument(IGraphArgument argument, IInputValue value)
+        /// <param name="origin">The origin in a query document where the argument was generated.</param>
+        public InputArgument(IGraphArgument argument, IInputValue value, SourceOrigin origin)
         {
             this.Argument = Validation.ThrowIfNullOrReturn(argument, nameof(argument));
             this.Value = Validation.ThrowIfNullOrReturn(value, nameof(value));
+            this.Origin = origin;
         }
 
         /// <summary>
@@ -50,10 +62,17 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         public IInputValue Value { get; }
 
         /// <summary>
-        /// Gets or sets the underlying field that represents
+        /// Gets the underlying field that represents
         /// this argument on the target schema.
         /// </summary>
         /// <value>The argument.</value>
-        public IGraphArgument Argument { get; set; }
+        public IGraphArgument Argument { get; }
+
+        /// <summary>
+        /// Gets the origin in a query document, if any, where this argument was
+        /// created.
+        /// </summary>
+        /// <value>The origin location in a query document.</value>
+        public SourceOrigin Origin { get; }
     }
 }

--- a/src/graphql-aspnet/Execution/QueryPlans/InputArguments/InputArgumentCollection.cs
+++ b/src/graphql-aspnet/Execution/QueryPlans/InputArguments/InputArgumentCollection.cs
@@ -61,19 +61,6 @@ namespace GraphQL.AspNet.Execution.QueryPlans.InputArguments
         }
 
         /// <inheritdoc />
-        public IExecutionArgumentCollection Merge(IResolvedVariableCollection variableData)
-        {
-            var collection = new ExecutionArgumentCollection(_arguments.Count);
-            foreach (var arg in _arguments.Values)
-            {
-                var resolvedValue = arg.Value.Resolve(variableData);
-                collection.Add(new ExecutionArgument(arg.Argument, resolvedValue));
-            }
-
-            return collection;
-        }
-
-        /// <inheritdoc />
         public bool Contains(string name)
         {
             return _arguments.ContainsKey(name);

--- a/src/graphql-aspnet/Execution/Source/SourceOrigin.cs
+++ b/src/graphql-aspnet/Execution/Source/SourceOrigin.cs
@@ -14,6 +14,7 @@ namespace GraphQL.AspNet.Execution.Source
     /// <summary>
     /// A complete represention (location and path) of a place within a query's source text.
     /// </summary>
+    [Serializable]
     public readonly struct SourceOrigin
     {
         /// <summary>

--- a/src/graphql-aspnet/Execution/Variables/InputNullValueVariable.cs
+++ b/src/graphql-aspnet/Execution/Variables/InputNullValueVariable.cs
@@ -14,10 +14,10 @@ namespace GraphQL.AspNet.Execution.Variables
     using GraphQL.AspNet.Interfaces.Execution.Variables;
 
     /// <summary>
-    /// A variable representing a variable value passed as <c>null</c>.
+    /// An item representing a variable value as being <c>null</c>.
     /// </summary>
     [DebuggerDisplay("InputValue: {Name}  (Value = null)")]
-    internal class InputNullValueVariable : InputVariable, IInputSingleValueVariable, IResolvableNullValue
+    internal sealed class InputNullValueVariable : InputVariable, IInputSingleValueVariable, IResolvableNullValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="InputNullValueVariable" /> class.

--- a/src/graphql-aspnet/Execution/Variables/ResolvedVariable.cs
+++ b/src/graphql-aspnet/Execution/Variables/ResolvedVariable.cs
@@ -20,34 +20,31 @@ namespace GraphQL.AspNet.Execution.Variables
     internal class ResolvedVariable : IResolvedVariable
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResolvedVariable"/> class.
+        /// Initializes a new instance of the <see cref="ResolvedVariable" /> class.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="typeExpression">The type expression.</param>
         /// <param name="value">The value.</param>
-        public ResolvedVariable(string name, GraphTypeExpression typeExpression, object value)
+        /// <param name="isDefaultValue">if set to <c>true</c>, indicates that <paramref name="value"/>
+        /// is the default value declared on the original variable definition..</param>
+        public ResolvedVariable(string name, GraphTypeExpression typeExpression, object value, bool isDefaultValue = false)
         {
             this.Name = Validation.ThrowIfNullWhiteSpaceOrReturn(name, nameof(name));
             this.TypeExpression = Validation.ThrowIfNullOrReturn(typeExpression, nameof(typeExpression));
             this.Value = value;
+            this.IsDefaultValue = isDefaultValue;
         }
 
-        /// <summary>
-        /// Gets the name of the variable as it was declared in the user's supplied data.
-        /// </summary>
-        /// <value>The name.</value>
+        /// <inheritdoc />
         public string Name { get; }
 
-        /// <summary>
-        /// Gets the value of the variable as a fully resolved .NET object.
-        /// </summary>
-        /// <value>The value.</value>
+        /// <inheritdoc />
         public object Value { get; }
 
-        /// <summary>
-        /// Gets the type expression this variable represents.
-        /// </summary>
-        /// <value>The type expression.</value>
+        /// <inheritdoc />
         public GraphTypeExpression TypeExpression { get; }
+
+        /// <inheritdoc />
+        public bool IsDefaultValue { get; }
     }
 }

--- a/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
+++ b/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
@@ -11,6 +11,7 @@ namespace GraphQL.AspNet.Execution.Variables
 {
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Execution.Parsing.NodeBuilders;
     using GraphQL.AspNet.Execution.QueryPlans;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
@@ -39,8 +40,6 @@ namespace GraphQL.AspNet.Execution.Variables
             IVariableCollectionDocumentPart variableCollection)
             : this(schema, variableCollection, new GraphMessageCollection())
         {
-            _schema = Validation.ThrowIfNullOrReturn(schema, nameof(schema));
-            _variableCollection = Validation.ThrowIfNullOrReturn(variableCollection, nameof(variableCollection));
         }
 
         /// <summary>
@@ -73,8 +72,10 @@ namespace GraphQL.AspNet.Execution.Variables
         {
             var resolverGenerator = new InputValueResolverMethodGenerator(_schema);
             var result = new ResolvedVariableCollection();
+
             foreach (var variable in _variableCollection)
             {
+
                 try
                 {
                     var resolver = resolverGenerator.CreateResolver(variable.TypeExpression);
@@ -86,19 +87,34 @@ namespace GraphQL.AspNet.Execution.Variables
                     if (inputVariables != null)
                         found = inputVariables.TryGetVariable(variable.Name, out suppliedValue);
 
+                    if (!found && !variable.HasDefaultValue)
+                    {
+                        var operationName = _variableCollection.Operation.Name ?? "~anonymous~";
+                        this.Messages.Critical(
+                             $"The declared variable '{variable.Name}' for operation '{operationName}' is required but was not supplied.",
+                             Constants.ErrorCodes.INVALID_VARIABLE_VALUE,
+                             _variableCollection.Operation.SourceLocation.AsOrigin());
+
+                        continue;
+                    }
                     resolvableItem = found ? suppliedValue : variable.DefaultValue;
+
 
                     object resolvedValue = resolver.Resolve(resolvableItem);
 
-                    var resolvedVariable = new ResolvedVariable(variable.Name, variable.TypeExpression, resolvedValue);
+                    var resolvedVariable = new ResolvedVariable(variable.Name, variable.TypeExpression, resolvedValue, !found);
 
+                    // validate nullability of the provided value against the TypeExpression of the declaration
+                    // on the operation
                     if (!resolvedVariable.TypeExpression.IsNullable && resolvedVariable.Value == null)
                     {
+                        var operationName = _variableCollection.Operation.Name ?? "~anonymous~";
                         this.Messages.Critical(
                              "The resolved variable value of <null> is not valid for non-nullable variable " +
-                             $"'{resolvedVariable.Name}'",
+                             $"'{resolvedVariable.Name}' on operation '{operationName}'",
                              Constants.ErrorCodes.INVALID_VARIABLE_VALUE,
                              _variableCollection.Operation.SourceLocation.AsOrigin());
+                        continue;
                     }
 
                     result.AddVariable(resolvedVariable);

--- a/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
+++ b/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
@@ -22,7 +22,7 @@ namespace GraphQL.AspNet.Execution.Variables
 
     /// <summary>
     /// An object that attempts to convert the untyped keyvalue pairs (usually pulled from a json doc)
-    /// into context-sensitive variables for a specific operation in a query document.
+    /// into context-sensitive variable values for a specific operation in a query document.
     /// </summary>
     public class ResolvedVariableGenerator
     {
@@ -75,7 +75,6 @@ namespace GraphQL.AspNet.Execution.Variables
 
             foreach (var variable in _variableCollection)
             {
-
                 try
                 {
                     var resolver = resolverGenerator.CreateResolver(variable.TypeExpression);

--- a/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
+++ b/src/graphql-aspnet/Execution/Variables/ResolvedVariableGenerator.cs
@@ -96,8 +96,8 @@ namespace GraphQL.AspNet.Execution.Variables
 
                         continue;
                     }
-                    resolvableItem = found ? suppliedValue : variable.DefaultValue;
 
+                    resolvableItem = found ? suppliedValue : variable.DefaultValue;
 
                     object resolvedValue = resolver.Resolve(resolvableItem);
 
@@ -120,8 +120,12 @@ namespace GraphQL.AspNet.Execution.Variables
                 }
                 catch (UnresolvedValueException svce)
                 {
+                    var messsage =
+                        $"The value for variable '{variable.Name}' was not resolvable " +
+                        $"to the expected type expression of '{variable.TypeExpression}'. Details: {svce.Message}";
+
                     this.Messages.Critical(
-                       svce.Message,
+                       messsage,
                        Constants.ErrorCodes.INVALID_VARIABLE_VALUE,
                        _variableCollection.Operation.SourceLocation.AsOrigin(),
                        exceptionThrown: svce.InnerException);

--- a/src/graphql-aspnet/Interfaces/Execution/QueryPlans/DocumentParts/IVariableDocumentPart.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/QueryPlans/DocumentParts/IVariableDocumentPart.cs
@@ -34,5 +34,11 @@ namespace GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts
         /// </summary>
         /// <value>The default value.</value>
         ISuppliedValueDocumentPart DefaultValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this variable instance has a declared <see cref="DefaultValue"/>.
+        /// </summary>
+        /// <value><c>true</c> if this instance has a default value; otherwise, <c>false</c>.</value>
+        bool HasDefaultValue { get; }
     }
 }

--- a/src/graphql-aspnet/Interfaces/Execution/QueryPlans/InputArguments/IInputArgumentCollection.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/QueryPlans/InputArguments/IInputArgumentCollection.cs
@@ -26,15 +26,6 @@ namespace GraphQL.AspNet.Interfaces.Execution.QueryPlans.InputArguments
         void Add(InputArgument input);
 
         /// <summary>
-        /// Merges the supplied variable data into a new collection of arguments
-        /// capable of fulfilling a request. Any deferred arguments in this instance are resolved
-        /// to the data contained in the provided dataset or null if not found.
-        /// </summary>
-        /// <param name="variableData">The variable data.</param>
-        /// <returns>IInputArgumentCollection.</returns>
-        IExecutionArgumentCollection Merge(IResolvedVariableCollection variableData);
-
-        /// <summary>
         /// Determines whether the read-only dictionary contains an element that has the specified key.
         /// </summary>
         /// <param name="name">The name of the variable to locate.</param>

--- a/src/graphql-aspnet/Interfaces/Execution/Variables/IResolvedVariable.cs
+++ b/src/graphql-aspnet/Interfaces/Execution/Variables/IResolvedVariable.cs
@@ -34,5 +34,15 @@ namespace GraphQL.AspNet.Interfaces.Execution.Variables
         /// </summary>
         /// <value>The type expression.</value>
         GraphTypeExpression TypeExpression { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this resolved variable value represents a declared default value.
+        /// </summary>
+        /// <remarks>
+        /// When <c>false</c>, indicates that the <see cref="Value"/> was explicitly supplied. When <c>true</c>, indicates that
+        /// no variable value was supplied and that <see cref="Value"/> is the default value declared on the operation.
+        /// </remarks>
+        /// <value><c>true</c> if this instance is default value; otherwise, <c>false</c>.</value>
+        bool IsDefaultValue { get; }
     }
 }

--- a/src/graphql-aspnet/Interfaces/Schema/IDefaultValueSchemaItem.cs
+++ b/src/graphql-aspnet/Interfaces/Schema/IDefaultValueSchemaItem.cs
@@ -1,0 +1,38 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Interfaces.Schema
+{
+    /// <summary>
+    /// A schema item that defines an optional default value.
+    /// </summary>
+    public interface IDefaultValueSchemaItem : ISchemaItem
+    {
+        /// <summary>
+        /// Gets a value indicating whether this instance was explictly marked as required, meaning it
+        /// must be supplied on a query.
+        /// </summary>
+        /// <value><c>true</c> if this instance is required; otherwise, <c>false</c>.</value>
+        bool IsRequired { get; }
+
+        /// <summary>
+        /// Gets a default value to use for any instances of this schema item when one is not explicitly provided.
+        /// The default can be <c>null</c>. Inspect <see cref="HasDefaultValue"/>
+        /// to determine if a default value is present.
+        /// </summary>
+        /// <value>The boxed, default value, if any.</value>
+        object DefaultValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance has a defined <see cref="DefaultValue"/>.
+        /// </summary>
+        /// <value><c>true</c> if this instance has a default value; otherwise, <c>false</c>.</value>
+        bool HasDefaultValue { get; }
+    }
+}

--- a/src/graphql-aspnet/Interfaces/Schema/IGraphArgument.cs
+++ b/src/graphql-aspnet/Interfaces/Schema/IGraphArgument.cs
@@ -15,7 +15,7 @@ namespace GraphQL.AspNet.Interfaces.Schema
     /// <summary>
     /// An argument/input value that can be applied to a field.
     /// </summary>
-    public interface IGraphArgument : ITypedSchemaItem, ISchemaItem
+    public interface IGraphArgument : ITypedSchemaItem, IDefaultValueSchemaItem, ISchemaItem
     {
         /// <summary>
         /// Clones this instance to a new argument.
@@ -23,20 +23,6 @@ namespace GraphQL.AspNet.Interfaces.Schema
         /// <param name="parent">The parent item to assign the newly cloned argument to.</param>
         /// <returns>IGraphField.</returns>
         IGraphArgument Clone(ISchemaItem parent);
-
-        /// <summary>
-        /// Gets a default value to use for any instances of this argument when one is not explicitly provided.
-        /// The default can be <c>null</c>. Inspect <see cref="HasDefaultValue"/>
-        /// to determine if a default value is present.
-        /// </summary>
-        /// <value>The boxed, default value, if any.</value>
-        object DefaultValue { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance has a defined <see cref="DefaultValue"/>.
-        /// </summary>
-        /// <value><c>true</c> if this instance has a default value; otherwise, <c>false</c>.</value>
-        bool HasDefaultValue { get; }
 
         /// <summary>
         /// Gets the argument modifiers that modify how this argument is interpreted by the runtime.

--- a/src/graphql-aspnet/Internal/Resolvers/EnumInputValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/EnumInputValueResolver.cs
@@ -52,7 +52,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
                 return _enumResolver.Resolve(value.AsSpan());
             }
 
-            throw this.CreateUnresolvableValueException(resolvableItem);
+            throw new UnresolvedValueException("Unresolvable enum data value.");
         }
     }
 }

--- a/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
@@ -118,27 +118,12 @@ namespace GraphQL.AspNet.Internal.Resolvers
                 }
                 else if (actualField.TypeExpression.IsNonNullable)
                 {
-                    // if the field is not required (meaning it has a default value)
-                    // the dfault value is already set by the instantiation of the
-                    // input object, no set action is actually required
-                    //
-                    // we just need to validate that hte field does indeed
-                    // have a default value (isRequired == false)
-                    if (actualField.IsRequired)
-                    {
-                        // the document validation rules
-                        // should prevent this scenario from ever happening
-                        // but trap it just in case to give a helpful exception
-                        SourceOrigin origin = default;
-                        if (resolvableItem is IDocumentPart docPart)
-                            origin = docPart.Origin;
-
-                        throw new GraphExecutionException(
-                            $"Unable to resolve type '{_graphType.Name}'. Field " +
-                            $"'{actualField.Name}' received a null value but is non-nullable " +
-                            $"and has no default value.",
-                            origin);
-                    }
+                    // a non-nullable field may receive a null value if a
+                    // variable supplying the value was explicitly supplied as null
+                    // on the query.
+                    throw new UnresolvedValueException(
+                        $"Unable to resolve type '{_graphType.Name}'. Field " +
+                        $"'{actualField.Name}' received a null value but is non-nullable.");
                 }
             }
 

--- a/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
@@ -78,20 +78,5 @@ namespace GraphQL.AspNet.Internal.Resolvers
 
             return false;
         }
-
-        /// <summary>
-        /// Creates a new exception indicating that the given resolvable item was not resolvable
-        /// via this instance.
-        /// </summary>
-        /// <param name="resolvableItem">The resolvable item that was unsuccessful.</param>
-        /// <returns>Exception.</returns>
-        protected virtual Exception CreateUnresolvableValueException(IResolvableValueItem resolvableItem)
-        {
-            var origin = SourceOrigin.None;
-            if (resolvableItem is IDocumentPart dp)
-                origin = dp.Origin;
-
-            return new GraphExecutionException("Unable to resolve the supplied resolvable enum value to an acceptable value", origin);
-        }
     }
 }

--- a/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
@@ -1,0 +1,97 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Internal.Resolvers
+{
+    using System;
+    using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Execution.Source;
+    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
+    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.Resolvables;
+    using GraphQL.AspNet.Interfaces.Execution.Variables;
+    using GraphQL.AspNet.Interfaces.Schema;
+
+    /// <summary>
+    /// A base class providing common functionality to many input value resolvers.
+    /// </summary>
+    internal abstract class InputValueResolverBase
+    {
+        private readonly IDefaultValueSchemaItem _defaultValueProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputValueResolverBase"/> class.
+        /// </summary>
+        /// <param name="defaultValueProvider">A provider that can supply a default value when such value is warranted
+        /// during value resolution.</param>
+        protected InputValueResolverBase(IDefaultValueSchemaItem defaultValueProvider)
+        {
+            _defaultValueProvider = defaultValueProvider;
+        }
+
+        /// <summary>
+        /// Tries to the value via common, universal methods for many scenarios (nullability, variables etc.)
+        /// </summary>
+        /// <param name="resolvableItem">The resolvable item.</param>
+        /// <param name="variableData">The variable data.</param>
+        /// <param name="resolvedValue">When successful, this parameter will be populated
+        /// with the resolved value.</param>
+        /// <returns><c>true</c> if the value was successfully resolved, <c>false</c> otherwise.</returns>
+        protected bool TryResolveViaCommonMethods(
+            IResolvableValueItem resolvableItem,
+            IResolvedVariableCollection variableData,
+            out object resolvedValue)
+        {
+            resolvedValue = null;
+
+            if (resolvableItem is IResolvableNullValue)
+                return true;
+
+            if (variableData != null && resolvableItem is IResolvablePointer pointer)
+            {
+                var variableFound = variableData.TryGetValue(pointer.PointsTo, out var variableValue);
+                if (variableFound)
+                {
+                    resolvedValue = variableValue.Value;
+
+                    // A note exists on rule 5.8.5 (https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist)
+                    // saying that IF a variable is not supplied (meaning default value was used) and IF the default value that was used for the variable is
+                    // null and IF the target location defines a default value
+                    // the default value of the target location should be used instead
+                    if (variableValue.Value == null
+                        && variableValue.IsDefaultValue
+                        && _defaultValueProvider != null
+                        && _defaultValueProvider.HasDefaultValue)
+                    {
+                        resolvedValue = _defaultValueProvider.DefaultValue;
+                        return true;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Creates a new exception indicating that the given resolvable item was not resolvable
+        /// via this instance.
+        /// </summary>
+        /// <param name="resolvableItem">The resolvable item that was unsuccessful.</param>
+        /// <returns>Exception.</returns>
+        protected virtual Exception CreateUnresolvableValueException(IResolvableValueItem resolvableItem)
+        {
+            var origin = SourceOrigin.None;
+            if (resolvableItem is IDocumentPart dp)
+                origin = dp.Origin;
+
+            return new GraphExecutionException("Unable to resolve the supplied resolvable enum value to an acceptable value", origin);
+        }
+    }
+}

--- a/src/graphql-aspnet/Internal/Resolvers/ListInputValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/ListInputValueResolver.cs
@@ -14,6 +14,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
     using System.Collections.Generic;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Common.Generics;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.Resolvables;
     using GraphQL.AspNet.Interfaces.Execution.Variables;
@@ -60,7 +61,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
                 return listInstance;
             }
 
-            throw this.CreateUnresolvableValueException(resolvableItem);
+            throw new UnresolvedValueException("Invalid or unresolvable list data value.");
         }
     }
 }

--- a/src/graphql-aspnet/Internal/Resolvers/ListInputValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/ListInputValueResolver.cs
@@ -17,12 +17,13 @@ namespace GraphQL.AspNet.Internal.Resolvers
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.Resolvables;
     using GraphQL.AspNet.Interfaces.Execution.Variables;
+    using GraphQL.AspNet.Interfaces.Schema;
 
     /// <summary>
     /// A higher order resolver that coerces the provided source data into a list of
     /// items of the provided singular input value resolver.
     /// </summary>
-    internal class ListInputValueResolver : IInputValueResolver
+    internal class ListInputValueResolver : InputValueResolverBase, IInputValueResolver
     {
         private readonly IInputValueResolver _itemResolver;
         private readonly Type _listItemType;
@@ -31,8 +32,10 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// Initializes a new instance of the <see cref="ListInputValueResolver" /> class.
         /// </summary>
         /// <param name="listItemType">The expected type of the item in the list.</param>
-        /// <param name="itemResolver">The item resolver that can generate instances of <paramref name="listItemType"/>.</param>
-        public ListInputValueResolver(Type listItemType, IInputValueResolver itemResolver)
+        /// <param name="itemResolver">The item resolver that can generate instances of <paramref name="listItemType" />.</param>
+        /// <param name="defaultValueProvider">The default value provider.</param>
+        public ListInputValueResolver(Type listItemType, IInputValueResolver itemResolver, IDefaultValueSchemaItem defaultValueProvider)
+            : base(defaultValueProvider)
         {
             _itemResolver = Validation.ThrowIfNullOrReturn(itemResolver, nameof(itemResolver));
             _listItemType = Validation.ThrowIfNullOrReturn(listItemType, nameof(listItemType));
@@ -41,13 +44,8 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// <inheritdoc />
         public object Resolve(IResolvableValueItem resolvableItem, IResolvedVariableCollection variableData = null)
         {
-            if (resolvableItem is IResolvablePointer pointer)
-            {
-                IResolvedVariable variable = null;
-                var variableFound = variableData?.TryGetValue(pointer.PointsTo, out variable) ?? false;
-                if (variableFound)
-                    return variable.Value;
-            }
+            if (this.TryResolveViaCommonMethods(resolvableItem, variableData, out var resolvedValue))
+                return resolvedValue;
 
             if (resolvableItem is IResolvableList resolvableList)
             {
@@ -62,7 +60,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
                 return listInstance;
             }
 
-            return null;
+            throw this.CreateUnresolvableValueException(resolvableItem);
         }
     }
 }

--- a/src/graphql-aspnet/Internal/Resolvers/ScalarInputValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/ScalarInputValueResolver.cs
@@ -48,7 +48,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
             if (resolvableItem is IResolvableValue resolvableValue)
                 return _scalarResolver.Resolve(resolvableValue.ResolvableValue);
 
-            throw this.CreateUnresolvableValueException(resolvableItem);
+            throw new UnresolvedValueException("Unresolvable scalar data value.");
         }
     }
 }

--- a/src/graphql-aspnet/Internal/Resolvers/ScalarInputValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/ScalarInputValueResolver.cs
@@ -11,15 +11,19 @@ namespace GraphQL.AspNet.Internal.Resolvers
 {
     using System;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Execution.Exceptions;
+    using GraphQL.AspNet.Execution.Source;
     using GraphQL.AspNet.Interfaces.Execution;
+    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.Resolvables;
     using GraphQL.AspNet.Interfaces.Execution.Variables;
+    using GraphQL.AspNet.Interfaces.Schema;
 
     /// <summary>
     /// A resolver that operates in context of a field input value that can
     /// generate a qualified .NET object for the provided scalar data.
     /// </summary>
-    internal class ScalarInputValueResolver : IInputValueResolver
+    internal class ScalarInputValueResolver : InputValueResolverBase, IInputValueResolver
     {
         private readonly ILeafValueResolver _scalarResolver;
 
@@ -27,7 +31,10 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// Initializes a new instance of the <see cref="ScalarInputValueResolver" /> class.
         /// </summary>
         /// <param name="scalarResolver">The resolver to resolve a scalar leaf value.</param>
-        public ScalarInputValueResolver(ILeafValueResolver scalarResolver)
+        /// <param name="defaultValueProvider">A provider that can supply a default value when such value is warranted
+        /// during value resolution.</param>
+        public ScalarInputValueResolver(ILeafValueResolver scalarResolver, IDefaultValueSchemaItem defaultValueProvider)
+            : base(defaultValueProvider)
         {
             _scalarResolver = Validation.ThrowIfNullOrReturn(scalarResolver, nameof(scalarResolver));
         }
@@ -35,18 +42,13 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// <inheritdoc />
         public virtual object Resolve(IResolvableValueItem resolvableItem, IResolvedVariableCollection variableData = null)
         {
-            if (resolvableItem is IResolvablePointer pointer)
-            {
-                IResolvedVariable variable = null;
-                var variableFound = variableData?.TryGetValue(pointer.PointsTo, out variable) ?? false;
-                if (variableFound)
-                    return variable.Value;
-            }
+            if (this.TryResolveViaCommonMethods(resolvableItem, variableData, out var resolvedValue))
+                return resolvedValue;
 
             if (resolvableItem is IResolvableValue resolvableValue)
                 return _scalarResolver.Resolve(resolvableValue.ResolvableValue);
 
-            return null;
+            throw this.CreateUnresolvableValueException(resolvableItem);
         }
     }
 }

--- a/src/graphql-aspnet/Middleware/DirectiveExecution/Components/InvokeDirectiveResolverMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/DirectiveExecution/Components/InvokeDirectiveResolverMiddleware.cs
@@ -32,11 +32,13 @@ namespace GraphQL.AspNet.Middleware.DirectiveExecution.Components
             // build a collection of invokable parameters from the supplied context
             if (context.IsValid && !context.IsCancelled)
             {
-                var generator = new ExecutionArgumentGenerator(
-                     context.Request.InvocationContext.Arguments,
-                     context.Messages);
+                var isSuccessful = ExecutionArgumentGenerator.TryConvert(
+                    context.Request.InvocationContext.Arguments,
+                    context.VariableData,
+                    context.Messages,
+                    out var executionArguments);
 
-                if (!generator.TryConvert(context.VariableData, out var executionArguments))
+                if (!isSuccessful)
                 {
                     context.Cancel();
                 }

--- a/src/graphql-aspnet/Middleware/FieldExecution/Components/InvokeFieldResolverMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/FieldExecution/Components/InvokeFieldResolverMiddleware.cs
@@ -95,11 +95,13 @@ namespace GraphQL.AspNet.Middleware.FieldExecution.Components
         {
             // Step 1: Build a collection of arguments from the supplied context that will
             //         be supplied to the resolver
-            var generator = new ExecutionArgumentGenerator(
+            var isSuccessful = ExecutionArgumentGenerator.TryConvert(
                 context.InvocationContext.Arguments,
-                context.Messages);
+                context.VariableData,
+                context.Messages,
+                out var executionArguments);
 
-            if (!generator.TryConvert(context.VariableData, out var executionArguments))
+            if (!isSuccessful)
             {
                 context.Cancel();
                 return false;

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
@@ -39,6 +39,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
         private readonly TSchema _schema;
         private readonly ISchemaPipeline<TSchema, GraphDirectiveExecutionContext> _directivePipeline;
         private readonly IQueryDocumentGenerator<TSchema> _documentGenerator;
+        private readonly ArgumentGenerator _argumentGenerator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplyExecutionDirectivesMiddleware{TSchema}" /> class.
@@ -56,6 +57,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
             _schema = Validation.ThrowIfNullOrReturn(schema, nameof(schema));
             _directivePipeline = Validation.ThrowIfNullOrReturn(directivePipeline, nameof(directivePipeline));
             _documentGenerator = Validation.ThrowIfNullOrReturn(documentGenerator, nameof(documentGenerator));
+            _argumentGenerator = new ArgumentGenerator(_schema);
         }
 
         /// <inheritdoc />
@@ -261,13 +263,11 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
             IDirective targetDirective,
             IDirectiveDocumentPart directivePart)
         {
-            var argGenerator = new ArgumentGenerator(_schema, directivePart.Arguments);
-
             var collection = new InputArgumentCollection(targetDirective.Arguments.Count);
             for (var i = 0; i < targetDirective.Arguments.Count; i++)
             {
                 var directiveArg = targetDirective.Arguments[i];
-                var argResult = argGenerator.CreateInputArgument(directiveArg);
+                var argResult = _argumentGenerator.CreateInputArgument(directivePart.Arguments, directiveArg);
                 if (argResult.IsValid)
                     collection.Add(argResult.Argument);
                 else

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ApplyExecutionDirectivesMiddleware.cs
@@ -269,7 +269,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 var directiveArg = targetDirective.Arguments[i];
                 var argResult = argGenerator.CreateInputArgument(directiveArg);
                 if (argResult.IsValid)
-                    collection.Add(new InputArgument(directiveArg, argResult.Argument));
+                    collection.Add(argResult.Argument);
                 else
                     queryContext.Messages.Add(argResult.Message);
             }

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateOperationVariableDataMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/ValidateOperationVariableDataMiddleware.cs
@@ -9,22 +9,18 @@
 
 namespace GraphQL.AspNet.Middleware.QueryExecution.Components
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution.Contexts;
-    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Execution.Variables;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
-    using GraphQL.AspNet.Interfaces.Execution.Variables;
     using GraphQL.AspNet.Interfaces.Middleware;
     using GraphQL.AspNet.Interfaces.Schema;
-    using Microsoft.Extensions.Configuration;
 
     /// <summary>
-    /// Validates that for a chosen operation, the supplied, external variable values can be coerced into
-    /// the required types for the operation.
+    /// Validates that, for a chosen operation, the supplied, external variable values can be coerced into
+    /// the required types for each variable definition.
     /// </summary>
     /// <typeparam name="TSchema">The type of schema this middleware component works for.</typeparam>
     internal class ValidateOperationVariableDataMiddleware<TSchema> : IQueryExecutionMiddleware

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphArgumentModifiersExtensions.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphArgumentModifiersExtensions.cs
@@ -8,6 +8,8 @@
 // *************************************************************
 namespace GraphQL.AspNet.Schemas.TypeSystem
 {
+    using System.Runtime.CompilerServices;
+
     /// <summary>
     /// Extension helper methods for <see cref="GraphArgumentModifiers"/>.
     /// </summary>
@@ -42,6 +44,18 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public static bool IsCancellationToken(this GraphArgumentModifiers modifiers)
         {
             return modifiers.HasFlag(GraphArgumentModifiers.CancellationToken);
+        }
+
+        /// <summary>
+        /// Determines whether the modifiers indicate that the argument is, for one reason or another,
+        /// not part of the externally exposed schema. This method cannot determine
+        /// what special type of argument is represented, only that it is special.
+        /// </summary>
+        /// <param name="modifiers">The modifiers to check.</param>
+        /// <returns><c>true</c> if the modifiers indicate the argument is not part of the schema; otherwise, <c>false</c>.</returns>
+        public static bool IsNotPartOfTheSchema(this GraphArgumentModifiers modifiers)
+        {
+            return modifiers != GraphArgumentModifiers.None;
         }
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphArgumentModifiersExtensions.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphArgumentModifiersExtensions.cs
@@ -55,7 +55,18 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         /// <returns><c>true</c> if the modifiers indicate the argument is not part of the schema; otherwise, <c>false</c>.</returns>
         public static bool IsNotPartOfTheSchema(this GraphArgumentModifiers modifiers)
         {
-            return modifiers != GraphArgumentModifiers.None;
+            return !modifiers.IsPartOfTheSchema();
+        }
+
+        /// <summary>
+        /// Determines whether the modifiers indicate that the argument is included in a
+        /// an externally exposed schema.
+        /// </summary>
+        /// <param name="modifiers">The modifiers to check.</param>
+        /// <returns><c>true</c> if the modifiers indicate the argument is part of the schema; otherwise, <c>false</c>.</returns>
+        public static bool IsPartOfTheSchema(this GraphArgumentModifiers modifiers)
+        {
+            return modifiers == GraphArgumentModifiers.None;
         }
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
@@ -124,5 +124,8 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
 
         /// <inheritdoc />
         public ISchemaItem Parent { get; }
+
+        /// <inheritdoc />
+        public bool IsRequired => !this.HasDefaultValue;
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/InputGraphField.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/InputGraphField.cs
@@ -32,6 +32,8 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         /// <param name="objectType">The .NET type of the item or items that represent the graph type returned by this field.</param>
         /// <param name="declaredReturnType">The .NET type as it was declared on the property which generated this field..</param>
         /// <param name="isRequired">if set to <c>true</c> this field was explicitly marked as being required.</param>
+        /// <param name="defaultValue">When <paramref name="isRequired"/> is <c>false</c>, represents
+        /// the value that should be used for this field when its not declared on a query document.</param>
         /// <param name="directives">The directives to apply to this field when its added to a schema.</param>
         public InputGraphField(
             string fieldName,
@@ -41,6 +43,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
             Type objectType,
             Type declaredReturnType,
             bool isRequired,
+            object defaultValue = null,
             IAppliedDirectiveCollection directives = null)
         {
             this.Name = Validation.ThrowIfNullWhiteSpaceOrReturn(fieldName, nameof(fieldName));
@@ -53,7 +56,8 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
             this.AppliedDirectives = directives?.Clone(this) ?? new AppliedDirectiveCollection(this);
 
             this.InternalName = declaredPropertyName;
-            this.IsRequired = isRequired;
+            this.HasDefaultValue = !isRequired;
+            this.DefaultValue = this.HasDefaultValue ? defaultValue : null;
             this.Publish = true;
         }
 
@@ -99,6 +103,12 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public string InternalName { get; }
 
         /// <inheritdoc />
-        public bool IsRequired { get; }
+        public object DefaultValue { get; }
+
+        /// <inheritdoc />
+        public bool HasDefaultValue { get; }
+
+        /// <inheritdoc />
+        public bool IsRequired => !this.HasDefaultValue;
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/Introspection/Model/IntrospectedType.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/Introspection/Model/IntrospectedType.cs
@@ -191,23 +191,17 @@ namespace GraphQL.AspNet.Schemas.TypeSystem.Introspection.Model
             if (!(this.GraphType is IInputObjectGraphType inputType))
                 return;
 
-            var defaultObject = InstanceFactory.CreateInstance(inputType.ObjectType);
-            var propGetters = InstanceFactory.CreatePropertyGetterInvokerCollection(inputType.ObjectType);
-
             // populate inputFields collection
             // populate the fields for this object type
             var inputFields = new List<IntrospectedInputValueType>();
             foreach (var field in inputType.Fields)
             {
-                object defaultValue = null;
-                if (field.IsRequired)
+                object defaultValue = field.DefaultValue;
+                if (field.IsRequired || !field.HasDefaultValue)
                 {
+                    // ensure the introspection system does not attach a default
+                    // value when not allowed to
                     defaultValue = IntrospectionNoDefaultValue.Instance;
-                }
-                else if (propGetters.ContainsKey(field.InternalName))
-                {
-                    var getter = propGetters[field.InternalName];
-                    defaultValue = getter.Invoke(ref defaultObject);
                 }
 
                 var introspectedType = introspectedSchema.FindIntrospectedType(field.TypeExpression.TypeName);

--- a/src/graphql-aspnet/Schemas/TypeSystem/VirtualGraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/VirtualGraphFieldArgument.cs
@@ -101,5 +101,8 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
 
         /// <inheritdoc />
         public ISchemaItem Parent { get; }
+
+        /// <inheritdoc />
+        public bool IsRequired => !this.HasDefaultValue;
     }
 }

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
@@ -215,13 +215,12 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         {
             var context = this.CreateExecutionContext();
 
-            var generator = new ExecutionArgumentGenerator(
-                 context.InvocationContext.Arguments,
-                 context.Messages);
-
-            generator.TryConvert(
+            ExecutionArgumentGenerator.TryConvert(
+                context.InvocationContext.Arguments,
                 context.VariableData,
-                out var executionArguments);
+                context.Messages,
+                out var executionArguments
+                );
 
             executionArguments = executionArguments.ForContext(context);
 

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
@@ -219,8 +219,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
                 context.InvocationContext.Arguments,
                 context.VariableData,
                 context.Messages,
-                out var executionArguments
-                );
+                out var executionArguments);
 
             executionArguments = executionArguments.ForContext(context);
 

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
@@ -214,11 +214,16 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         public FieldResolutionContext CreateResolutionContext()
         {
             var context = this.CreateExecutionContext();
-            var executionArguments = context
-                .InvocationContext
-                .Arguments
-                .Merge(context.VariableData)
-                .ForContext(context);
+
+            var generator = new ExecutionArgumentGenerator(
+                 context.InvocationContext.Arguments,
+                 context.Messages);
+
+            generator.TryConvert(
+                context.VariableData,
+                out var executionArguments);
+
+            executionArguments = executionArguments.ForContext(context);
 
             return new FieldResolutionContext(
                 _schema,

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/FieldContextBuilder.cs
@@ -148,7 +148,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         {
             var resolvedInputValue = new ResolvedInputArgumentValue(argumentName, value);
             var fieldArgument = _graphField.Arguments[argumentName];
-            var inputArgument = new InputArgument(fieldArgument, resolvedInputValue);
+            var inputArgument = new InputArgument(fieldArgument, resolvedInputValue, SourceOrigin.None);
             _arguments.Add(inputArgument);
             return this;
         }

--- a/src/unit-tests/graphql-aspnet-tests/Controllers/ActionResults/ActionResultTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Controllers/ActionResults/ActionResultTests.cs
@@ -129,7 +129,7 @@ namespace GraphQL.AspNet.Tests.Controllers.ActionResults
 
             Assert.IsTrue(context.IsCancelled);
             Assert.AreEqual(1, context.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.UNHANDLED_EXCEPTION, context.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INTERNAL_SERVER_ERROR, context.Messages[0].Code);
             Assert.IsTrue(context.Messages[0].Message.Contains("An unhandled exception was thrown during"));
             Assert.AreEqual(exception, context.Messages[0].Exception);
         }
@@ -145,7 +145,7 @@ namespace GraphQL.AspNet.Tests.Controllers.ActionResults
 
             Assert.IsTrue(context.IsCancelled);
             Assert.AreEqual(1, context.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.UNHANDLED_EXCEPTION, context.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INTERNAL_SERVER_ERROR, context.Messages[0].Code);
             Assert.AreEqual("big fail", context.Messages[0].Message);
             Assert.AreEqual(exception, context.Messages[0].Exception);
         }

--- a/src/unit-tests/graphql-aspnet-tests/Controllers/ControllerTestData/InputModelForModelState.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Controllers/ControllerTestData/InputModelForModelState.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Controllers.ControllerTestData
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class InputModelForModelState
+    {
+        [StringLength(5)]
+        public string Name { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Controllers/ControllerTestData/InvokableController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Controllers/ControllerTestData/InvokableController.cs
@@ -14,6 +14,8 @@ namespace GraphQL.AspNet.Tests.Controllers.ControllerTestData
     using System.Threading.Tasks;
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Controllers.InputModel;
+    using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Interfaces.Controllers;
 
     [GraphRoute("invoke")]
@@ -50,6 +52,54 @@ namespace GraphQL.AspNet.Tests.Controllers.ControllerTestData
         public IGraphActionResult ErrorResult()
         {
             return this.Error("an error happened", "12345", new Exception("exception text"));
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult InternalServerErrorResult()
+        {
+            return this.InternalServerError("Server error");
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult NotFoundResult()
+        {
+            return this.NotFound("thing wasnt found");
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult UnauthorizedResult()
+        {
+            return this.Unauthorized("nope not authorized");
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult OkNoObjectResult()
+        {
+            return this.Ok();
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult BadRequestMessageResult()
+        {
+            return this.BadRequest("it was bad");
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult BadRequestModelResult(InputModelForModelState model)
+        {
+            if (!this.ModelState.IsValid)
+                return this.BadRequest(this.ModelState);
+
+            return this.Ok();
+        }
+
+        [Query(typeof(string))]
+        public IGraphActionResult ErrorResultBySeverity()
+        {
+            return this.Error(
+                GraphMessageSeverity.Warning,
+                "my message",
+                "my code");
         }
 
         public Dictionary<string, object> CapturedItems { get; }

--- a/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
@@ -101,9 +101,6 @@ namespace GraphQL.AspNet.Tests.Directives
             if (_reason != "do-not-add")
                 executionArgs.Add(new ExecutionArgument(_directive.Arguments[0], _reason));
 
-            _argCollection.Setup(x => x.Merge(It.IsAny<IResolvedVariableCollection>()))
-                .Returns(executionArgs);
-
             _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
             _invocationContext = new DirectiveInvocationContext(

--- a/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/DeprecatedDirectiveTests.cs
@@ -83,14 +83,15 @@ namespace GraphQL.AspNet.Tests.Directives
 
             _arg = new InputArgument(
                 _directive.Arguments[0],
-                _argValue.Object);
+                _argValue.Object,
+                SourceOrigin.None);
 
             var argList = new List<InputArgument>();
             argList.Add(_arg);
 
             _argCollection = new Mock<IInputArgumentCollection>();
             _argCollection.Setup(m => m.GetEnumerator())
-                .Returns(argList.GetEnumerator());
+                .Returns(() => argList.GetEnumerator());
 
             _logger = new Mock<IGraphEventLogger>();
         }
@@ -98,7 +99,7 @@ namespace GraphQL.AspNet.Tests.Directives
         private async Task<GraphDirectiveExecutionContext> ExecuteRequest()
         {
             var executionArgs = new ExecutionArgumentCollection();
-            if (_reason != "do-not-add")
+            if (_reason == "do-not-add")
                 executionArgs.Add(new ExecutionArgument(_directive.Arguments[0], _reason));
 
             _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
@@ -153,20 +154,6 @@ namespace GraphQL.AspNet.Tests.Directives
             var item = _directiveTarget as IGraphField;
             Assert.IsTrue(item.IsDeprecated);
             Assert.IsNull(item.DeprecationReason);
-        }
-
-        [Test]
-        public async Task NoReasonSupplied_ReasonIsSetToDefault()
-        {
-            _directiveLocation = DirectiveLocation.FIELD_DEFINITION;
-            _reason = "do-not-add";
-            _directiveTarget = _schema.AllSchemaItems().First(x => x.IsField<TwoPropertyObject>("property1"));
-
-            var context = await this.ExecuteRequest();
-
-            var item = _directiveTarget as IGraphField;
-            Assert.IsTrue(item.IsDeprecated);
-            Assert.AreEqual("No longer supported", item.DeprecationReason);
         }
 
         [Test]

--- a/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
@@ -94,9 +94,6 @@ namespace GraphQL.AspNet.Tests.Directives
             var executionArgs = new ExecutionArgumentCollection();
             executionArgs.Add(new ExecutionArgument(_directive.Arguments[0], _url));
 
-            _argCollection.Setup(x => x.Merge(It.IsAny<IResolvedVariableCollection>()))
-                .Returns(executionArgs);
-
             _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
             _invocationContext = new DirectiveInvocationContext(

--- a/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Directives/SpecifiedByDirectiveTests.cs
@@ -33,6 +33,7 @@ namespace GraphQL.AspNet.Tests.Directives
     using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
+    using GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.QueryInputValueSteps;
 
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
@@ -77,23 +78,21 @@ namespace GraphQL.AspNet.Tests.Directives
 
             _arg = new InputArgument(
                 _directive.Arguments[0],
-                _argValue.Object);
+                _argValue.Object,
+                SourceOrigin.None);
 
             var argList = new List<InputArgument>();
             argList.Add(_arg);
 
             _argCollection = new Mock<IInputArgumentCollection>();
             _argCollection.Setup(m => m.GetEnumerator())
-                .Returns(argList.GetEnumerator());
+                .Returns(() => argList.GetEnumerator());
 
             _logger = new Mock<IGraphEventLogger>();
         }
 
         private async Task<GraphDirectiveExecutionContext> ExecuteRequest()
         {
-            var executionArgs = new ExecutionArgumentCollection();
-            executionArgs.Add(new ExecutionArgument(_directive.Arguments[0], _url));
-
             _queryRequest = new QueryExecutionRequest(GraphQueryData.Empty);
 
             _invocationContext = new DirectiveInvocationContext(

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InputTestObjectWithDefaultFieldValues.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InputTestObjectWithDefaultFieldValues.cs
@@ -1,0 +1,33 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    using System.ComponentModel.DataAnnotations;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class InputTestObjectWithDefaultFieldValues
+    {
+        public InputTestObjectWithDefaultFieldValues()
+        {
+            this.Prop1 = 34;
+            this.Prop2 = "default prop2 string";
+            this.Prop4 = new TwoPropertyObject("twoPropString1", 99);
+        }
+
+        public int Prop1 { get; set; }
+
+        public string Prop2 { get; set; }
+
+        [Required]
+        public int Prop3 { get; set; }
+
+        public TwoPropertyObject Prop4 { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/DefaultGraphResponseWriterTests.cs
@@ -223,7 +223,7 @@ namespace GraphQL.AspNet.Tests.Execution
                                         ""throwsException""
                                       ],
                                       ""extensions"": {
-                                        ""code"": ""UNHANDLED_EXCEPTION"",
+                                        ""code"": ""INTERNAL_SERVER_ERROR"",
                                         ""timestamp"": """ + fixedDate.ToRfc3339String() + @""",
                                         ""severity"": ""CRITICAL"",
                                         ""exception"": {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/ExecutionDirectiveTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/ExecutionDirectiveTests.cs
@@ -167,9 +167,7 @@ namespace GraphQL.AspNet.Tests.Execution
         [Test]
         public async Task ExecutionDirectiveAddsAFieldPostProcessor_ForSingleField_ProcessorIsExecutedAsExpected()
         {
-            var directiveInstance = new SampleDirective();
             var builder = new TestServerBuilder();
-            builder.AddSingleton(directiveInstance);
             builder.AddGraphController<DirectiveTestController>()
                   .AddDirective<ToUpperCaseExecutionDirective>();
 
@@ -199,9 +197,7 @@ namespace GraphQL.AspNet.Tests.Execution
         [Test]
         public async Task ExecutionDirectiveAddsAFieldPostProcessor_ForTypeExtensionField_ProcessorIsExecutedAsExpected()
         {
-            var directiveInstance = new SampleDirective();
             var builder = new TestServerBuilder();
-            builder.AddSingleton(directiveInstance);
             builder.AddGraphController<DirectiveTestController>()
                   .AddDirective<ToUpperCaseExecutionDirective>();
 
@@ -231,9 +227,7 @@ namespace GraphQL.AspNet.Tests.Execution
         [Test]
         public async Task ExecutionDirectiveAddsAFieldPostProcessor_ForBatchExtensionField_ProcessorIsExecutedAsExpected()
         {
-            var directiveInstance = new SampleDirective();
             var builder = new TestServerBuilder();
-            builder.AddSingleton(directiveInstance);
             builder.AddGraphController<DirectiveTestController>()
                   .AddDirective<AdjustBatchDataDirective>();
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -177,7 +177,7 @@ namespace GraphQL.AspNet.Tests.Execution
 
             Assert.AreEqual(1, result.Messages.Count);
             Assert.AreEqual(GraphMessageSeverity.Critical, result.Messages.Severity);
-            Assert.AreEqual(Constants.ErrorCodes.UNHANDLED_EXCEPTION, result.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INTERNAL_SERVER_ERROR, result.Messages[0].Code);
             Assert.IsNotNull(result.Messages[0].Exception);
             Assert.AreEqual("Failure from Controller", result.Messages[0].Exception.Message);
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
@@ -285,8 +285,11 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task NonNullableInputFieldWithDefaultValue_WhenVariableSuppliedIsNull_UsesDefaultValue()
+        public async Task NonNullableInputFieldWithDefaultValue_WhenVariableSuppliedViaDefaultNull_UsesDefaultValueOfField()
         {
+            // Direct Test of:
+            // https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist
+
             var server = new TestServerBuilder()
                   .AddGraphQL(o =>
                   {
@@ -296,7 +299,7 @@ namespace GraphQL.AspNet.Tests.Execution
                   .Build();
 
             // simple.nonNullableInputField.inputFIeld.id has a argument of type Int!
-            // but receives null via the variable
+            // but receives null via the default value of the variable
             // however, since the field has a default value defined (because its not required)
             // the value resolves correctly
             var builder = server.CreateQueryContextBuilder()

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
@@ -289,7 +289,6 @@ namespace GraphQL.AspNet.Tests.Execution
         {
             // Direct Test of:
             // https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist
-
             var server = new TestServerBuilder()
                   .AddGraphQL(o =>
                   {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Parsing/SourceTextLexerExtensionsTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Parsing/SourceTextLexerExtensionsTests.cs
@@ -8,7 +8,7 @@
 // *************************************************************
 
 // ReSharper disable All
-namespace GraphQL.AspNet.Tests.Parsing2
+namespace GraphQL.AspNet.Tests.Parsing
 {
     using System;
     using System.Linq;

--- a/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
@@ -38,14 +38,14 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
             var queryInputCollection = document.Operations["TestQuery"]
                 .FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchString"].Arguments;
 
             var arg1 = graphFieldArguments["arg1"];
 
-            var result = argGenerator.CreateInputArgument(arg1);
+            var result = argGenerator.CreateInputArgument(queryInputCollection,arg1);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
@@ -69,13 +69,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var queryInputCollection = document.Operations["TestQuery"].FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchString"].Arguments;
             var arg2 = graphFieldArguments["arg2"];
 
-            var result = argGenerator.CreateInputArgument(arg2);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg2);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
@@ -102,13 +102,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var queryInputCollection = document.Operations["TestQuery"].FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchString"].Arguments;
             var arg1 = graphFieldArguments["arg1"];
 
-            var result = argGenerator.CreateInputArgument(arg1);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg1);
 
             Assert.IsNotNull(result);
             Assert.IsFalse((bool)result.IsValid);
@@ -133,13 +133,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var queryInputCollection = document.Operations["TestQuery"].FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchArrayTotal"].Arguments;
             var arg3 = graphFieldArguments["arg3"];
 
-            var result = argGenerator.CreateInputArgument(arg3);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg3);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
@@ -168,13 +168,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var queryInputCollection = document.Operations["TestQuery"].FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchArrayTotal"].Arguments;
             var arg3 = graphFieldArguments["arg3"];
 
-            var result = argGenerator.CreateInputArgument(arg3);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg3);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
@@ -206,13 +206,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var queryInputCollection = document.Operations["TestQuery"].FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchComplexValue"].Arguments;
             var arg3 = graphFieldArguments["arg4"];
 
-            var result = argGenerator.CreateInputArgument(arg3);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg3);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
@@ -250,13 +250,13 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
             var queryInputCollection = document.Operations["TestQuery"]
                 .FieldSelectionSet.ExecutableFields[0].FieldSelectionSet.ExecutableFields[0].Arguments;
 
-            var argGenerator = new ArgumentGenerator(server.Schema, queryInputCollection);
+            var argGenerator = new ArgumentGenerator(server.Schema);
 
             var schemaType = server.Schema.KnownTypes.FindGraphType("Query_Input");
             var graphFieldArguments = (schemaType as IGraphFieldContainer).Fields["fetchComplexValue"].Arguments;
             var arg3 = graphFieldArguments["arg4"];
 
-            var result = argGenerator.CreateInputArgument(arg3);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg3);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);

--- a/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
@@ -49,10 +49,10 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as ResolvedInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as ResolvedInputArgumentValue);
 
             Assert.IsNull(result.Message);
-            var data = result.Argument.Resolve(ResolvedVariableCollection.Empty);
+            var data = result.Argument.Value.Resolve(ResolvedVariableCollection.Empty);
             Assert.AreEqual(5, data);
         }
 
@@ -79,11 +79,11 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as ResolvedInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as ResolvedInputArgumentValue);
             Assert.IsNull(result.Message);
 
             // default value on the parameter
-            var data = result.Argument.Resolve(ResolvedVariableCollection.Empty);
+            var data = result.Argument.Value.Resolve(ResolvedVariableCollection.Empty);
             Assert.AreEqual(15, data);
         }
 
@@ -112,7 +112,7 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsFalse((bool)result.IsValid);
-            Assert.IsNull(result.Argument as ResolvedInputArgumentValue);
+            Assert.IsNull(result.Argument?.Value as ResolvedInputArgumentValue);
 
             Assert.IsNotNull(result.Message);
             Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Message.Code);
@@ -143,10 +143,10 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as ResolvedInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as ResolvedInputArgumentValue);
             Assert.IsNull(result.Message);
 
-            var data = result.Argument.Resolve(ResolvedVariableCollection.Empty) as IEnumerable<int>;
+            var data = result.Argument.Value.Resolve(ResolvedVariableCollection.Empty) as IEnumerable<int>;
             Assert.IsNotNull(data);
 
             var expected = new List<int> { 1, 2, 3 };
@@ -178,7 +178,7 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as DeferredInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as DeferredInputArgumentValue);
             Assert.IsNull(result.Message);
         }
 
@@ -216,10 +216,10 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as ResolvedInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as ResolvedInputArgumentValue);
             Assert.IsNull(result.Message);
 
-            var data = result.Argument.Resolve(ResolvedVariableCollection.Empty) as TwoPropertyObject;
+            var data = result.Argument.Value.Resolve(ResolvedVariableCollection.Empty) as TwoPropertyObject;
             Assert.IsNotNull(data);
             Assert.AreEqual("bob", data.Property1);
             Assert.AreEqual(10, data.Property2);
@@ -260,7 +260,7 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);
-            Assert.IsNotNull(result.Argument as DeferredInputArgumentValue);
+            Assert.IsNotNull(result.Argument.Value as DeferredInputArgumentValue);
             Assert.IsNull(result.Message);
         }
     }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
@@ -45,7 +45,7 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
 
             var arg1 = graphFieldArguments["arg1"];
 
-            var result = argGenerator.CreateInputArgument(queryInputCollection,arg1);
+            var result = argGenerator.CreateInputArgument(queryInputCollection, arg1);
 
             Assert.IsNotNull(result);
             Assert.IsTrue((bool)result.IsValid);

--- a/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/QueryPlans/ArgumentGeneratorTests.cs
@@ -115,7 +115,7 @@ namespace GraphQL.AspNet.Tests.Execution.QueryPlans
             Assert.IsNull(result.Argument?.Value as ResolvedInputArgumentValue);
 
             Assert.IsNotNull(result.Message);
-            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Message.Code);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT_VALUE, result.Message.Code);
         }
 
         [Test]

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
@@ -29,7 +29,7 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             QueriesToFail.Add(new object[] { ruleNumberToBreak, query });
         }
 
-        private static void AddQuerySuccess(string query)
+        private static void AddQuerySuccess(string relatedRule, string query)
         {
             QueriesToPass.Add(new object[] { query });
         }
@@ -202,6 +202,9 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: SOMEENUM) { id name } } }");
             AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: true) { id name } } }");
 
+            // passing null for Input_Elevator is successfull
+            AddQuerySuccess("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: null) { id name } } }");
+
             // elevator.id value requires a non-null integer
             AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { elevator(id: null) { id name } } }");
 
@@ -249,6 +252,9 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
 
             // all variable must be used ($var2 is not referenced through fragment)
             AddQueryFailure("5.8.4", "query Operation1($var1: Int!, $var2: String){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name } } ");
+
+            // all ariables must be used ($var1 IS referenced through fragment)
+            AddQuerySuccess("5.8.4", "query Operation1($var1: Int!){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name } } ");
 
             // all variable must be valid where used ($var1 is an int as required by elevator:id)
             AddQueryFailure(
@@ -301,18 +307,21 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             // var1 is declared as an Int with 18 default, e.id is declared
             // as Int! with no valid default, 18 is acceptable to e.id
             AddQuerySuccess(
+                "5.8.5",
                 "query Operation1($var1: Int = 18){ peopleMovers { matchElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
 
             // 5.8.5 Positive Test
             // var1 declares a nullable, but required variable (must be supplied); e.id is declred as Int! but DOES declare
             // a default value of 35 whichis acceptable
             AddQuerySuccess(
+                "5.8.5",
                 "query Operation1($var1: Int){ peopleMovers { matchDefaultValueElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
 
             // 5.8.5 Positive Test
             // var1 declares a default value of <null>; e.id is declred as Int! but DOES declare
             // a default value of 35 whichis acceptable
             AddQuerySuccess(
+                "5.8.5",
                 "query Operation1($var1: Int = null){ peopleMovers { matchDefaultValueElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
         }
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
@@ -21,52 +21,59 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
     [TestFixture]
     public class DocumentValidationRuleProcessorTests
     {
-        public static readonly List<object> TestQueries;
+        public static readonly List<object> QueriesToFail;
+        public static readonly List<object> QueriesToPass;
 
-        private static void AddQuery(string ruleNumberToBreak, string query)
+        private static void AddQueryFailure(string ruleNumberToBreak, string query)
         {
-            TestQueries.Add(new object[] { ruleNumberToBreak, query });
+            QueriesToFail.Add(new object[] { ruleNumberToBreak, query });
+        }
+
+        private static void AddQuerySuccess(string query)
+        {
+            QueriesToPass.Add(new object[] { query });
         }
 
         static DocumentValidationRuleProcessorTests()
         {
-            TestQueries = new List<object>();
+            QueriesToFail = new List<object>();
+            QueriesToPass = new List<object>();
 
             // no such operation type as 'fakeOperationType'
-            AddQuery("5.1.1", "fakeOperationType Operation1{ peopleMovers { elevator(id: 5){id, name} } }");
+            AddQueryFailure("5.1.1", "fakeOperationType Operation1{ peopleMovers { elevator(id: 5){id, name} } }");
 
             // mutation is not valid in this schema
-            AddQuery("5.2", "mutation Operation1{ peopleMovers { elevator(id: 5){id, name } } }");
+            AddQueryFailure("5.2", "mutation Operation1{ peopleMovers { elevator(id: 5){id, name } } }");
 
             // duplciate named operations
-            AddQuery("5.2.1.1", "query Operation1{ peopleMovers { elevator(id: 5){id, name } } }" +
+            AddQueryFailure("5.2.1.1", "query Operation1{ peopleMovers { elevator(id: 5){id, name } } }" +
                                 "query Operation1{ peopleMovers { elevator(id: 8){id, name } } }");
 
             // Anonymous operation must be declared alone
-            AddQuery("5.2.2.1", "{ peopleMovers { elevator(id: 5){id, name} } }" +
+            AddQueryFailure("5.2.2.1", "{ peopleMovers { elevator(id: 5){id, name} } }" +
                                 "query Operation1{ peopleMovers { elevator(id: 8){id, name } } }");
 
-            AddQuery("5.2.2.1", "query { peopleMovers { elevator(id: 5){id, name} } }" +
+            AddQueryFailure("5.2.2.1", "query { peopleMovers { elevator(id: 5){id, name} } }" +
                                 "query { peopleMovers { elevator(id: 8){id, name } } }");
 
             // field "search" not declared on "query"
-            AddQuery("5.3.1", "{ search { " +
+            AddQueryFailure("5.3.1", "{ search { " +
                               "     id, name " +
                               "}}");
 
             // search returns a union. Unions cannot directly contain fields (other than __typename)
-            AddQuery("5.3.1", "{ peopleMovers { search { " +
+            AddQueryFailure("5.3.1", "{ peopleMovers { search { " +
                               "     id " +
                               "}}}");
 
             // return names at same level must be identidical (different input values)
-            AddQuery("5.3.2", "{ peopleMovers { " +
+            AddQueryFailure("5.3.2", "{ peopleMovers { " +
                               "     elevator(id: 5) { id, name }" +
                               "     elevator(id: 18) { id, name } " +
                               "}}");
 
             // return names at same level must be identical (aliased to same name but different return types)
-            AddQuery("5.3.2", "{ peopleMovers { " +
+            AddQueryFailure("5.3.2", "{ peopleMovers { " +
                               "     elevator(id: 5) { id, name }" +
                               "     elevator: escalator(id: 5) { id, name } " +
                               "}}");
@@ -77,7 +84,7 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             // field but with different arguments, these are not mergable
             // and should fail since both speed fields belong to the same
             // selection set on allPeopleMovers
-            AddQuery("5.3.2", @"query {
+            AddQueryFailure("5.3.2", @"query {
                                     peopleMovers {
                                        allPeopleMovers {
                                            ... on Elevator {
@@ -103,154 +110,154 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
                                 }");
 
             // leaf fields must not have a child field set (name is a string, it has no fields)
-            AddQuery("5.3.3", "query Operation1{ peopleMovers { elevator(id: 5){id, name { lastName } } } }");
+            AddQueryFailure("5.3.3", "query Operation1{ peopleMovers { elevator(id: 5){id, name { lastName } } } }");
 
             // non-leaf fields must have a child field set (elevator is an object)
-            AddQuery("5.3.3", "query Operation1{ peopleMovers { elevator(id: 5) } }");
+            AddQueryFailure("5.3.3", "query Operation1{ peopleMovers { elevator(id: 5) } }");
 
             // argument must be defined on the field in the schema  (notAnArg is not defined)
             // note: id is a required arg on the field (added to prevent a flag of rule 5.4.2.1 in this test)
-            AddQuery("5.4.1", "query Operation1{ peopleMovers { elevator(id: 5, notAnArg: 5){ id name } } }");
+            AddQueryFailure("5.4.1", "query Operation1{ peopleMovers { elevator(id: 5, notAnArg: 5){ id name } } }");
 
             // argument must be defined on the directive in the schema (notAnArg is not defined)
             // note: someValue is a required arg on restrict (added to prevent a flag of rule 5.4.2.1 in this test)
-            AddQuery("5.4.1", "query Operation1{ peopleMovers @restrict(notAnArg: 1, someValue: 1) { elevator(id: 5){ id name } } }");
+            AddQueryFailure("5.4.1", "query Operation1{ peopleMovers @restrict(notAnArg: 1, someValue: 1) { elevator(id: 5){ id name } } }");
 
             // arguments must be unique (field)
-            AddQuery("5.4.2", "query Operation1{ peopleMovers { elevator(id: 5, id: 5){ id name } } }");
+            AddQueryFailure("5.4.2", "query Operation1{ peopleMovers { elevator(id: 5, id: 5){ id name } } }");
 
             // arguments must be unique (directive)
-            AddQuery("5.4.2", "query Operation1{ peopleMovers @restrict(someValue: 1, someValue: 2) { elevator(id: 5){ id name } } }");
+            AddQueryFailure("5.4.2", "query Operation1{ peopleMovers @restrict(someValue: 1, someValue: 2) { elevator(id: 5){ id name } } }");
 
             // required argument must be provided (id is required on elevator but not provided)
-            AddQuery("5.4.2.1", "query Operation1{ peopleMovers { elevator(){ id name } } }");
+            AddQueryFailure("5.4.2.1", "query Operation1{ peopleMovers { elevator(){ id name } } }");
 
             // required argument must be provided ("someValue" required on @Restrict but not provided)
-            AddQuery("5.4.2.1", "query Operation1{ peopleMovers @restrict { elevator (id: 5) { id name } } }");
+            AddQueryFailure("5.4.2.1", "query Operation1{ peopleMovers @restrict { elevator (id: 5) { id name } } }");
 
             // named fragments must be unique
-            AddQuery("5.5.1.1", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on Elevator { id } fragment frag1 on Elevator { name} ");
+            AddQueryFailure("5.5.1.1", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on Elevator { id } fragment frag1 on Elevator { name} ");
 
             // named fragments must have a declared target type (no type on frag1)
-            AddQuery("5.5.1.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 { id }");
+            AddQueryFailure("5.5.1.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 { id }");
 
             // named fragments must have a declared target type (invalid type on frag1)
-            AddQuery("5.5.1.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on Bob { id }");
+            AddQueryFailure("5.5.1.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on Bob { id }");
 
             // inlined fragments must have a declared target type (invalid type bob)
-            AddQuery("5.5.1.2", "query Operation1{ peopleMover(id: 5) { ... on Bob  { id } } } ");
+            AddQueryFailure("5.5.1.2", "query Operation1{ peopleMover(id: 5) { ... on Bob  { id } } } ");
 
             // all declared target types of a fragment must be Union, interface or object on named fragment
             // frag 1 declars a target of the string scalar
-            AddQuery("5.5.1.3", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on String { unknownField1  }");
+            AddQueryFailure("5.5.1.3", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on String { unknownField1  }");
 
             // all declared target graph types must be Union, interface or object on inline fragment
-            AddQuery("5.5.1.3", "query Operation1{ peopleMovers { elevator(id: 5){ ... on String { unknownField1 } } } } ");
+            AddQueryFailure("5.5.1.3", "query Operation1{ peopleMovers { elevator(id: 5){ ... on String { unknownField1 } } } } ");
 
             // all declared named fragments must be spread at least once
-            AddQuery("5.5.1.4", "query Operation1{ peopleMovers { elevator(id: 5){ id name } } } fragment frag1 on Elevator { id }");
+            AddQueryFailure("5.5.1.4", "query Operation1{ peopleMovers { elevator(id: 5){ id name } } } fragment frag1 on Elevator { id }");
 
             // any spread named fragment must exist in the document
-            AddQuery("5.5.2.1", "query Operation1{ peopleMovers { elevator(id: 5){ id ...frag1 } } }");
+            AddQueryFailure("5.5.2.1", "query Operation1{ peopleMovers { elevator(id: 5){ id ...frag1 } } }");
 
             // spreading a named fragment must not form a cycle
-            AddQuery("5.5.2.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on Elevator { ...frag2 id name } fragment frag2 on Elevator { ...frag1 height} ");
+            AddQueryFailure("5.5.2.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on Elevator { ...frag2 id name } fragment frag2 on Elevator { ...frag1 height} ");
 
             // spreading a fragment: Object inside object (objects must match)
             // (Elevator is not an Escalator)
-            AddQuery("5.5.2.3.1", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on Escalator { id name }");
+            AddQueryFailure("5.5.2.3.1", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on Escalator { id name }");
 
             // spreading an inline fragment: Object inside object (objects must match)
             // (Elevator is not an Escalator)
-            AddQuery("5.5.2.3.1", "query Operation1{ peopleMovers { elevator(id: 5){ ... on Escalator {id} } } } ");
+            AddQueryFailure("5.5.2.3.1", "query Operation1{ peopleMovers { elevator(id: 5){ ... on Escalator {id} } } } ");
 
             // spreading a fragment: Abstract inside object (object must "be a part of" the abstract type)
             // (Elevator does not implement interface HoriztonalMover)
-            AddQuery("5.5.2.3.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on HorizontalMover { id }");
+            AddQueryFailure("5.5.2.3.2", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1 } } } fragment frag1 on HorizontalMover { id }");
 
             // spreading a inline fragment: Abstract inside object (object must "be a part of" the abstract type)
             // (Elevator does not implement interface HoriztonalMover)
-            AddQuery("5.5.2.3.2", "query Operation1{ peopleMovers { elevator(id: 5){ ... on HorizontalMover { id } } } }");
+            AddQueryFailure("5.5.2.3.2", "query Operation1{ peopleMovers { elevator(id: 5){ ... on HorizontalMover { id } } } }");
 
             // spreading a fragment: object inside an abstract (abstract must "contain" the object )
             // (HoriztonalMover is not implemented by Elevator)
-            AddQuery("5.5.2.3.3", "query Operation1{ peopleMovers { horizontalMover (id: \"5\"){ ...frag1 } } } fragment frag1 on Elevator { id name }");
+            AddQueryFailure("5.5.2.3.3", "query Operation1{ peopleMovers { horizontalMover (id: \"5\"){ ...frag1 } } } fragment frag1 on Elevator { id name }");
 
             // spreading a inline fragment: object inside an abstract (abstract must "contain" the object )
             // (HoriztonalMover is not implemented by Elevator)
-            AddQuery("5.5.2.3.3", "query Operation1{ peopleMovers { horizontalMover (id: \"5\"){ ...on Elevator { id name } } } }");
+            AddQueryFailure("5.5.2.3.3", "query Operation1{ peopleMovers { horizontalMover (id: \"5\"){ ...on Elevator { id name } } } }");
 
             // spreading a fragment: abstract inside an abstract (abstract must "contain" an intersection with other abstract)
             // (no object types implement both HorizontalMover and VerticalMover interfaces)
-            AddQuery("5.5.2.3.4", "query Operation1{ peopleMovers { horizontalMover(id: \"5\"){ ...frag1 } } } fragment frag1 on VerticalMover { id }");
+            AddQueryFailure("5.5.2.3.4", "query Operation1{ peopleMovers { horizontalMover(id: \"5\"){ ...frag1 } } } fragment frag1 on VerticalMover { id }");
 
             // spreading a inline fragment: abstract inside an abstract (abstract must "contain" an intersection with other abstract)
             // (no object types implement both HorizontalMover and VerticalMover interfaces)
-            AddQuery("5.5.2.3.4", "query Operation1{ peopleMovers { horizontalMover(id: \"5\"){ ...on VerticalMover { id } } } }");
+            AddQueryFailure("5.5.2.3.4", "query Operation1{ peopleMovers { horizontalMover(id: \"5\"){ ...on VerticalMover { id } } } }");
 
             // required argument must be provided (matchElevator accepts in an input object 'e' of type
             // "Input_Elevator", simulate passing all possible non-object types: number, stirng, enum, bool)
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: 5) { id name } } }");
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: \"someString\") { id name } } }");
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: SOMEENUM) { id name } } }");
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: true) { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: 5) { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: \"someString\") { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: SOMEENUM) { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { matchElevator(e: true) { id name } } }");
 
             // elevator.id value requires a non-null integer
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { elevator(id: null) { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { elevator(id: null) { id name } } }");
 
             // the supplied value of "someString" for input field "id" is not a number
-            AddQuery("5.6.1", "query Operation1{ peopleMovers { elevatorsByBuilding(building: {id: \"someString\"}) { id name } } }");
+            AddQueryFailure("5.6.1", "query Operation1{ peopleMovers { elevatorsByBuilding(building: {id: \"someString\"}) { id name } } }");
 
             // INPUT_OBJECT: type must contain no unknown properties for the target graph type
-            AddQuery("5.6.2", "query Operation1{ peopleMovers { matchElevator(e: {id: 5, nonExistantProp: 18}) { id name } } }");
+            AddQueryFailure("5.6.2", "query Operation1{ peopleMovers { matchElevator(e: {id: 5, nonExistantProp: 18}) { id name } } }");
 
             // INPUT_OBJECT:All properties on an input object must be unique
-            AddQuery("5.6.3", "query Operation1{ peopleMovers { matchElevator(e: {id: 5, id: 7, name: \"South Elevator\"} ) { id name } } }");
+            AddQueryFailure("5.6.3", "query Operation1{ peopleMovers { matchElevator(e: {id: 5, id: 7, name: \"South Elevator\"} ) { id name } } }");
 
             // INPUT_OBJECT:fields marked as "required" must be supplied  (id on field is marked required)
-            AddQuery("5.6.4", "query Operation1{ peopleMovers { matchElevator(e: {name: \"South Elevator\"}) { id name } } }");
+            AddQueryFailure("5.6.4", "query Operation1{ peopleMovers { matchElevator(e: {name: \"South Elevator\"}) { id name } } }");
 
             // INPUT_OBJECT: checks nested input objects on an input object  (address has a required field of id (Int!))
-            AddQuery("5.6.4", "query Operation1{ peopleMovers { elevatorsByBuilding(building: { id: 5, address: {name: \"shore line\"} }) { id name } } }");
+            AddQueryFailure("5.6.4", "query Operation1{ peopleMovers { elevatorsByBuilding(building: { id: 5, address: {name: \"shore line\"} }) { id name } } }");
 
             // directive must exist (no such directive as @NotARealThing)
-            AddQuery("5.7.1", "query Operation1{ peopleMovers @notARealThing { elevator (id: 5) { id name } } }");
+            AddQueryFailure("5.7.1", "query Operation1{ peopleMovers @notARealThing { elevator (id: 5) { id name } } }");
 
             // directive defined at appropriate locations (the restrict directive is not allowed at the "query" level)
-            AddQuery("5.7.2", "query Operation1 @restrict(someValue: 10) { peopleMovers { elevator (id: 5) { id name } } }");
+            AddQueryFailure("5.7.2", "query Operation1 @restrict(someValue: 10) { peopleMovers { elevator (id: 5) { id name } } }");
 
             // non-repeateable directive defined no more than once per location
-            AddQuery("5.7.3", "query Operation1{ peopleMovers  @restrict(someValue: 10)  @restrict(someValue: 10) { elevator (id: 5) { id name } } }");
+            AddQueryFailure("5.7.3", "query Operation1{ peopleMovers  @restrict(someValue: 10)  @restrict(someValue: 10) { elevator (id: 5) { id name } } }");
 
             // all variable names must be unique
-            AddQuery("5.8.1", "query Operation1($var1: Int!, $var1: Int!){ peopleMovers { elevator (id: $var1) { id name } } }");
+            AddQueryFailure("5.8.1", "query Operation1($var1: Int!, $var1: Int!){ peopleMovers { elevator (id: $var1) { id name } } }");
 
             // all variable must be of a valid type (HorizontalMover is an interface)
-            AddQuery("5.8.2", "query Operation1($var1: HorizontalMover){ peopleMovers { elevator (id: $var1) { id name } } }");
+            AddQueryFailure("5.8.2", "query Operation1($var1: HorizontalMover){ peopleMovers { elevator (id: $var1) { id name } } }");
 
             // all variable must be of a valid type (HorizontalMover is an interface)
-            AddQuery("5.8.2", "query Operation1($var1: HorizontalMover){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name }  } ");
+            AddQueryFailure("5.8.2", "query Operation1($var1: HorizontalMover){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name }  } ");
 
             // all used variables must be declared ($var2 is not declared)
-            AddQuery("5.8.3", "query Operation1($var1: Int!){ peopleMovers { elevator (id: $var1) @restrict(someValue: $var2) { id name } } }");
+            AddQueryFailure("5.8.3", "query Operation1($var1: Int!){ peopleMovers { elevator (id: $var1) @restrict(someValue: $var2) { id name } } }");
 
             // all used variables must be declared ($var2 in referenced fragment is not declared by the operation)
-            AddQuery("5.8.3", "query Operation1($var1: Int!){ peopleMovers { elevator (id: $var1) { id }  ...frag1 } } fragment frag1 on Query_PeopleMovers { ele: elevator(id:$var2) { id } }");
+            AddQueryFailure("5.8.3", "query Operation1($var1: Int!){ peopleMovers { elevator (id: $var1) { id }  ...frag1 } } fragment frag1 on Query_PeopleMovers { ele: elevator(id:$var2) { id } }");
 
             // all variable must be used ($var2 is not referenced)
-            AddQuery("5.8.4", "query Operation1($var1: Int!, $var2: String){ peopleMovers { elevator (id: $var1) { id name } } }");
+            AddQueryFailure("5.8.4", "query Operation1($var1: Int!, $var2: String){ peopleMovers { elevator (id: $var1) { id name } } }");
 
             // all variable must be used ($var2 is not referenced through fragment)
-            AddQuery("5.8.4", "query Operation1($var1: Int!, $var2: String){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name } } ");
+            AddQueryFailure("5.8.4", "query Operation1($var1: Int!, $var2: String){ peopleMovers { ...frag1 } } fragment frag1 on Query_PeopleMovers { elevator (id: $var1) { id name } } ");
 
             // all variable must be valid where used ($var1 is an int as required by elevator:id)
-            AddQuery(
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: String!){ peopleMovers { elevator (id: $var1) { id name } } }");
 
             // all variable must be valid where used ($var1 is an int as required by elevator:id but
             // fragment recieves a string from its operation)
-            AddQuery(
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: String!){ peopleMovers { ... frag1 } } fragment frag1 on Query_PeopleMovers {elevator (id: $var1) { id name } }");
 
@@ -258,40 +265,58 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             // $var1 is declared as a string but "horizontalMover" requires an "ID".
             // Special case where "GraphID" is declared as a string as well
             // but since type expressions don't match a failure must occur
-            AddQuery(
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: String!){ peopleMovers { horizontalMover (id: $var1) { id } } }");
 
             // var1 is declared as an Int, id accepts an Int!, value is denied because default is null
-            AddQuery(
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: Int = null){ peopleMover (id: $var1) { id } }");
 
             // var1 is declared as an Int, id accepts an Int!, value is denied because no default
-            // for the variable is declared
-            AddQuery(
+            // for the variable or target argument is declared
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: Int){ peopleMover (id: $var1) { id } }");
 
             // var1 is declared as an String!, the list item type is Int!, value should be denied
-            AddQuery(
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: String!){ escalators (ids: [$var1, 3]) { id } }");
 
             // var1 is declared as an Int with <null> default, verticalMove.id is declared
-            // as Int!
-            AddQuery(
+            // as Int! with no default value
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: Int = null){ peopleMovers { verticalMover (id: $var1) { id } } }");
 
-            // var1 is declared as an Int with <null> default, e.id is declared
-            // as Int!
-            AddQuery(
+            // var1 is declared as an Int with <null> default; e.id is declared
+            // as Int! with no default.
+            AddQueryFailure(
                 "5.8.5",
                 "query Operation1($var1: Int = null){ peopleMovers { matchElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
+
+            // 5.8.5 Positive Test
+            // var1 is declared as an Int with 18 default, e.id is declared
+            // as Int! with no valid default, 18 is acceptable to e.id
+            AddQuerySuccess(
+                "query Operation1($var1: Int = 18){ peopleMovers { matchElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
+
+            // 5.8.5 Positive Test
+            // var1 declares a nullable, but required variable (must be supplied); e.id is declred as Int! but DOES declare
+            // a default value of 35 whichis acceptable
+            AddQuerySuccess(
+                "query Operation1($var1: Int){ peopleMovers { matchDefaultValueElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
+
+            // 5.8.5 Positive Test
+            // var1 declares a default value of <null>; e.id is declred as Int! but DOES declare
+            // a default value of 35 whichis acceptable
+            AddQuerySuccess(
+                "query Operation1($var1: Int = null){ peopleMovers { matchDefaultValueElevator (e: {id: $var1 name: \"bob\" }) { id } } }");
         }
 
-        [TestCaseSource(nameof(TestQueries))]
+        [TestCaseSource(nameof(QueriesToFail))]
         public void ExecuteRule_EnsureCorrectErrorIsGenerated(string expectedRuleError, string queryText)
         {
             var server = new TestServerBuilder()
@@ -311,9 +336,11 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             // inspect for error codes
             if (document.Messages.Count != 1)
             {
-                var errors = Enumerable.Where<IGraphMessage>(document.Messages, x => x.MetaData != null &&
-                                                                         x.MetaData.ContainsKey("Rule"))
-                        .Select(x => x.MetaData["Rule"]);
+                var errors = Enumerable.Where<IGraphMessage>(
+                    document.Messages,
+                    x => x.MetaData != null &&
+                         x.MetaData.ContainsKey("Rule"))
+                                   .Select(x => x.MetaData["Rule"]);
 
                 string errorMessage = $"Expected 1 error ({expectedRuleError}) but recieved {document.Messages.Count}: '{string.Join(", ", errors)}'";
                 Assert.Fail(errorMessage);
@@ -325,6 +352,37 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
 
             var ruleBroke = message.MetaData["Rule"];
             Assert.AreEqual(expectedRuleError, ruleBroke.ToString());
+        }
+
+        [TestCaseSource(nameof(QueriesToPass))]
+        public void ExecuteRule_EnsureNoErrorsAreGenerated(string queryText)
+        {
+            var server = new TestServerBuilder()
+                .AddType<PeopleMoverController>()
+                .AddType<AllowDirective>()
+                .AddType<RestrictDirective>()
+                .Build();
+
+            // parse the query
+            var document = server.CreateDocument(queryText);
+
+            // execute the document validation
+            var validationContext = new DocumentValidationContext(server.Schema, document);
+            var processor = new DocumentValidationRuleProcessor();
+            processor.Execute(validationContext);
+
+            // inspect for error codes
+            if (document.Messages.Count != 0)
+            {
+                var errors = Enumerable.Where<IGraphMessage>(
+                    document.Messages,
+                    x => x.MetaData != null &&
+                         x.MetaData.ContainsKey("Rule"))
+                                   .Select(x => x.MetaData["Rule"]);
+
+                string errorMessage = $"Expected 0 errors but recieved {document.Messages.Count}: '{string.Join(", ", errors)}'";
+                Assert.Fail(errorMessage);
+            }
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/RuleCheckTestData/ElevatorBindingModel2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/RuleCheckTestData/ElevatorBindingModel2.cs
@@ -1,0 +1,30 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.RulesEngine.RuleCheckTestData
+{
+    using System.ComponentModel.DataAnnotations;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Schemas.TypeSystem;
+
+    [GraphType(PreventAutoInclusion = true)]
+    public class ElevatorBindingModel2
+    {
+        public ElevatorBindingModel2()
+        {
+            this.Id = 35;
+            this.Name = string.Empty;
+        }
+
+        public int Id { get; set; }
+
+        [GraphField("name", TypeExpression = "Type!")]
+        public string Name { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/RuleCheckTestData/PeopleMoverController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/RuleCheckTestData/PeopleMoverController.cs
@@ -60,6 +60,12 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine.RuleCheckTestData
             return null;
         }
 
+        [Query("matchDefaultValueElevator")]
+        public Elevator MatchElevator2(ElevatorBindingModel2 e)
+        {
+            return null;
+        }
+
         [Query("escalator")]
         public Escalator RetrieveEscalator(int id)
         {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/ModelWithIntWithDefaultValue.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/ModelWithIntWithDefaultValue.cs
@@ -1,0 +1,21 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
+{
+    public class ModelWithIntWithDefaultValue
+    {
+        public ModelWithIntWithDefaultValue()
+        {
+            this.Id = 98;
+        }
+
+        public int Id { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/ModelWithRequiredInt.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/ModelWithRequiredInt.cs
@@ -7,12 +7,13 @@
 // License:  MIT
 // *************************************************************
 
-namespace GraphQL.AspNet.Interfaces.Schema
+namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
 {
-    /// <summary>
-    /// A field of data on an INPUT_OBJECT graph type.
-    /// </summary>
-    public interface IInputGraphField : IGraphFieldBase, IDefaultValueSchemaItem, ITypedSchemaItem
+    using System.ComponentModel.DataAnnotations;
+
+    public class ModelWithRequiredInt
     {
+        [Required]
+        public int Id { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
@@ -62,6 +62,16 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
         }
 
         [MutationRoot]
+        public TwoPropertyObject CreateWithModelRequiredInt(ModelWithRequiredInt param)
+        {
+            return new TwoPropertyObject()
+            {
+                Property1 = "some value",
+                Property2 = param?.Id ?? -1,
+            };
+        }
+
+        [MutationRoot]
         public TwoPropertyObject CreateWithNullableId(GraphId? param)
         {
             return new TwoPropertyObject()

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
@@ -121,7 +121,6 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
             };
         }
 
-
         [MutationRoot]
         public TwoPropertyObject CreateWithIntWithDefaultValue(int param = 33)
         {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
@@ -19,6 +19,7 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
         {
             Value1,
             Value2,
+            Value3,
         }
 
         [MutationRoot]
@@ -123,6 +124,16 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
 
         [MutationRoot]
         public TwoPropertyObject CreateWithIntWithDefaultValue(int param = 33)
+        {
+            return new TwoPropertyObject()
+            {
+                Property1 = param.ToString(),
+                Property2 = 5,
+            };
+        }
+
+        [MutationRoot]
+        public TwoPropertyObject CreateWithEnumWithDefaultValue(TestEnum param = TestEnum.Value2)
         {
             return new TwoPropertyObject()
             {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/InputVariableExecutionTestData/NullableVariableObjectController.cs
@@ -32,6 +32,16 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
         }
 
         [MutationRoot]
+        public TwoPropertyObject CreateWithModelWithIntWithDefaultValue(ModelWithIntWithDefaultValue param)
+        {
+            return new TwoPropertyObject()
+            {
+                Property1 = param.Id.ToString(),
+                Property2 = 5,
+            };
+        }
+
+        [MutationRoot]
         public TwoPropertyObject CreateWithModelGuid(ModelWithGuid param)
         {
             return new TwoPropertyObject()
@@ -93,6 +103,17 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData
 
         [MutationRoot]
         public TwoPropertyObject CreateWithInt(int param)
+        {
+            return new TwoPropertyObject()
+            {
+                Property1 = param.ToString(),
+                Property2 = 5,
+            };
+        }
+
+
+        [MutationRoot]
+        public TwoPropertyObject CreateWithIntWithDefaultValue(int param = 33)
         {
             return new TwoPropertyObject()
             {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
@@ -1078,7 +1078,6 @@ namespace GraphQL.AspNet.Tests.Execution
             CommonAssertions.AreEqualJsonStrings(expectedJson, result);
         }
 
-
         [Test]
         public async Task SingleArgumentScalar_WithNotRequiredNonNullableInt_WhenVariableIsNotSupplied_DefaultValueOfVariableIsUsed_CausesErrorWhenDefaultIsInvalid()
         {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
@@ -9,6 +9,8 @@
 
 namespace GraphQL.AspNet.Tests.Execution
 {
+    using System.ComponentModel;
+    using System.ComponentModel.DataAnnotations;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Tests.Execution.TestData.InputVariableExecutionTestData;
@@ -27,8 +29,14 @@ namespace GraphQL.AspNet.Tests.Execution
                 .Build();
 
             var builder = server.CreateQueryContextBuilder();
+
+            builder.AddQueryText(
+                @"query($variable1: String) {
+                    scalarValue(arg1: $variable1)
+                  }");
+
             builder.AddVariableData("{ \"variable1\" : \"test string 86\" }");
-            builder.AddQueryText("query($variable1: String){ scalarValue(arg1: $variable1) }");
+
             var result = await server.RenderResult(builder);
 
             var expected = @"
@@ -49,8 +57,23 @@ namespace GraphQL.AspNet.Tests.Execution
                 .Build();
 
             var builder = server.CreateQueryContextBuilder();
-            builder.AddVariableData("{ \"variable1\" : { \"property1\" : \"value1\", \"property2\": 15 } }");
-            builder.AddQueryText("query($variable1: Input_TwoPropertyObject){ complexValue(arg1: $variable1) { property1 property2 } }");
+
+            builder.AddQueryText(
+                @"query($variable1: Input_TwoPropertyObject) {
+                    complexValue(arg1: $variable1) {
+                        property1
+                        property2
+                    }
+                }");
+
+            builder.AddVariableData(
+                @"{
+                    ""variable1"" : {
+                            ""property1"" : ""value1"",
+                            ""property2"": 15
+                    }
+                  }");
+
             var result = await server.RenderResult(builder);
 
             var expected = @"{
@@ -66,7 +89,7 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task NestedScalarVariable_IsUsedInsteadOfDefault()
+        public async Task ScalarVariable_NestedInInputObject_IsUsedInsteadOfDefault()
         {
             var server = new TestServerBuilder()
                 .AddType<InputValueController>()
@@ -78,10 +101,16 @@ namespace GraphQL.AspNet.Tests.Execution
 
             // variable passed is just 1 value of hte input object (not the whole thing)
             var builder = server.CreateQueryContextBuilder();
+            builder.AddQueryText(
+                @"query($variable1: String){
+                        complexValue(arg1: { property1: $variable1, property2: 15} ) {
+                            property1
+                            property2
+                        }
+                }");
+
             builder.AddVariableData("{ \"variable1\" : \"stringPassedValue\" }");
-            builder.AddQueryText("query($variable1: String){ " +
-                "complexValue(arg1: { property1: $variable1, property2: 15} ) " +
-                "{ property1 property2 } }");
+
             var result = await server.RenderResult(builder);
 
             var expected = @"{
@@ -109,11 +138,12 @@ namespace GraphQL.AspNet.Tests.Execution
 
             var builder = server.CreateQueryContextBuilder();
 
-            builder.AddVariableData("{ \"variable1\" : 4 }");
+            builder.AddQueryText(
+                @"query($variable1: Int!){
+                   sumListValues(arg1: [1,2,$variable1])
+                }");
 
-            builder.AddQueryText("query($variable1: Int!){ " +
-                "   sumListValues(arg1: [1,2,$variable1]) " +
-                "}");
+            builder.AddVariableData("{ \"variable1\" : 4 }");
 
             var result = await server.RenderResult(builder);
 
@@ -141,9 +171,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             builder.AddVariableData("{ \"variable1\" : 86 }");
 
-            builder.AddQueryText("query($variable1: Int!){ " +
-                "   sumListListValues(arg1: [[1,2],[$variable1, 4]]) " +
-                "}");
+            builder.AddQueryText(
+                @"query($variable1: Int!){
+                   sumListListValues(arg1: [[1,2],[$variable1, 4]])
+                }");
 
             var result = await server.RenderResult(builder);
 
@@ -171,9 +202,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             builder.AddVariableData("{ \"variable1\" : 74, \"variable2\" : 99 }");
 
-            builder.AddQueryText("query($variable1: Int!,$variable2: Int!){ " +
-                "   stupidDeepListValues(arg1: [[[[[[[1,2],[$variable1, 4]],[[$variable2, 6]]]]]]]) " +
-                "}");
+            builder.AddQueryText(
+                @"query($variable1: Int!,$variable2: Int!){
+                   stupidDeepListValues(arg1: [[[[[[[1,2],[$variable1, 4]],[[$variable2, 6]]]]]]])
+                }");
 
             var result = await server.RenderResult(builder);
 
@@ -269,20 +301,10 @@ namespace GraphQL.AspNet.Tests.Execution
                     }
                 }");
 
-            queryContext.AddVariableData(@"{ }");
-
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithModelGuid"" : {
-                        ""property1"" : null,
-                        ""property2"": 5
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -445,7 +467,7 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task NullableModelGuid_AsInputField_WhenNotSuppliedOnVariable_IsTreatedAsNull()
+        public async Task NullableModelGuid_AsInputField_WhenNotSuppliedOnVariable_RecordsError()
         {
             // github issue 95
             var builder = new TestServerBuilder();
@@ -463,18 +485,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             queryContext.AddVariableData(@"{ }");
 
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithModelGuid"" : {
-                        ""property1"" : null,
-                        ""property2"": 5
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -562,18 +576,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             queryContext.AddVariableData(@"{ }");
 
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithModelInt"" : {
-                        ""property1"" : ""some value"",
-                        ""property2"": -1
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -628,18 +634,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             queryContext.AddVariableData(@"{ }");
 
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithNullableId"" : {
-                        ""property1"" : null,
-                        ""property2"": 5
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -726,7 +724,7 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task NullableEnum_AsInputField_WhenNotSuppliedOnVariable_IsTreatedAsNull()
+        public async Task NullableEnum_AsInputField_WhenNotSuppliedOnVariable_ReturnsError()
         {
             // github issue 95
             var builder = new TestServerBuilder();
@@ -744,18 +742,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             queryContext.AddVariableData(@"{ }");
 
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithEnum"" : {
-                        ""property1"" : null,
-                        ""property2"": 5
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -810,18 +800,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
             queryContext.AddVariableData(@"{ }");
 
-            var expectedJson = @"
-            {
-                ""data"" : {
-                    ""createWithNullableInt"" : {
-                        ""property1"" : null,
-                        ""property2"": 5
-                    }
-                }
-            }";
-
-            var result = await server.RenderResult(queryContext);
-            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+            var result = await server.ExecuteQuery(queryContext);
+            Assert.IsTrue(result.Messages.Severity.IsCritical());
+            Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -950,8 +932,8 @@ namespace GraphQL.AspNet.Tests.Execution
                     }
                 }");
 
-            // No Variable data is supplied meaning the default value of param.id
-            // shoudl take effect
+            // No Variable data is supplied to a variable with a default value of null
+            // meaning the default value of param.id should take effect
             queryContext.AddVariableData(@"{ }");
 
             var expectedJson = @"
@@ -1003,7 +985,41 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task InputObject_WithNotRequiredNonNullableInt_WhenVariableIsSuppliedAsNull_ResultsIn585Error()
+        public async Task InputObject_WithNotRequiredNonNullableInt_WhenVariableSupplied_VariableValueIsUsed()
+        {
+            var builder = new TestServerBuilder();
+            builder.AddGraphController<NullableVariableObjectController>();
+            var server = builder.Build();
+
+            var queryContext = server.CreateQueryContextBuilder();
+            queryContext.AddQueryText(
+                @"mutation ($arg1: Int = 409){
+                    createWithModelWithIntWithDefaultValue(param: {id: $arg1} )  {
+                       property1
+                        property2
+                    }
+                }");
+
+            // No Variable data is supplied meaning the default value of param.id
+            // shoudl take effect
+            queryContext.AddVariableData(@"{ ""arg1"" : 65 }");
+
+            var expectedJson = @"
+            {
+                ""data"" : {
+                    ""createWithModelWithIntWithDefaultValue"" : {
+                        ""property1"" : ""65"",
+                        ""property2"": 5
+                    }
+                }
+            }";
+
+            var result = await server.RenderResult(queryContext);
+            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
+        }
+
+        [Test]
+        public async Task InputObject_WithNotRequiredNonNullableInt_WhenVariableIsSuppliedAsNull_FieldErrorOccurs()
         {
             var builder = new TestServerBuilder();
             builder.AddGraphController<NullableVariableObjectController>();
@@ -1019,18 +1035,13 @@ namespace GraphQL.AspNet.Tests.Execution
                 }");
 
             // Variable data is EXPLICITLY supplied as null, meaning the default value of param.id
-            // cannot take effect and 5.8.5 has been violated (
-            // https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist
+            // cannot take effect and a field error should occur
             queryContext.AddVariableData(@"{ ""arg1"" : null }");
 
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
-
-            var message = result.Messages[0];
-            Assert.IsTrue(message.MetaData.ContainsKey("Rule"));
-            var rule = message.MetaData["Rule"];
-            Assert.AreEqual("5.8.5", rule);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -1056,7 +1067,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var expectedJson = @"
             {
                 ""data"" : {
-                    ""createWithModelWithIntWithDefaultValue"" : {
+                    ""createWithIntWithDefaultValue"" : {
                         ""property1"" : ""11"",
                         ""property2"": 5
                     }
@@ -1067,9 +1078,8 @@ namespace GraphQL.AspNet.Tests.Execution
             CommonAssertions.AreEqualJsonStrings(expectedJson, result);
         }
 
-
         [Test]
-        public async Task SingleArgument_WithNotRequiredNonNullableInt_WhenVariableIsNotSupplied_DefaultValueIsUsed()
+        public async Task SingleArgument_WithNotRequiredNonNullableInt_WhenVariableIsNotSupplied_ArgumentDefaultValueIsUsed()
         {
             var builder = new TestServerBuilder();
             builder.AddGraphController<NullableVariableObjectController>();
@@ -1091,7 +1101,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var expectedJson = @"
             {
                 ""data"" : {
-                    ""createWithModelWithIntWithDefaultValue"" : {
+                    ""createWithIntWithDefaultValue"" : {
                         ""property1"" : ""33"",
                         ""property2"": 5
                     }
@@ -1103,7 +1113,7 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [Test]
-        public async Task SingleArgument_WithNotRequiredNonNullableInt_WhenVariableIsSuppliedAsNull_ResultsIn585Error()
+        public async Task SingleArgument_WithNotRequiredNonNullableInt_WhenVariableExplicitlySuppliedAsNull_FieldErrorOccurs()
         {
             var builder = new TestServerBuilder();
             builder.AddGraphController<NullableVariableObjectController>();
@@ -1121,17 +1131,45 @@ namespace GraphQL.AspNet.Tests.Execution
             queryContext.AddVariableData(@"{ ""arg1"" : null }");
 
             // Variable data is EXPLICITLY supplied as null, meaning the default value of param
-            // cannot take effect and 5.8.5 has been violated
-            // https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist
-
+            // cannot take effect and thus the value supplied cannot be used.
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
+        }
 
-            var message = result.Messages[0];
-            Assert.IsTrue(message.MetaData.ContainsKey("Rule"));
-            var rule = message.MetaData["Rule"];
-            Assert.AreEqual("5.8.5", rule);
+        [Test]
+        public async Task SingleArgument_WithNotRequiredNonNullableInt_WhenVariableIsSupplied_VariableValueIsUsed()
+        {
+            var builder = new TestServerBuilder();
+            builder.AddGraphController<NullableVariableObjectController>();
+            var server = builder.Build();
+
+            var queryContext = server.CreateQueryContextBuilder();
+            queryContext.AddQueryText(
+                @"mutation ($arg1: Int = null){
+                    createWithIntWithDefaultValue(param: $arg1)  {
+                       property1
+                        property2
+                    }
+                }");
+
+            // No Variable data is supplied for $arg1 meaning the default value of param
+            // should take effect
+            queryContext.AddVariableData(@"{ ""arg1"" : 2020 }");
+
+            var expectedJson = @"
+            {
+                ""data"" : {
+                    ""createWithIntWithDefaultValue"" : {
+                        ""property1"" : ""2020"",
+                        ""property2"": 5
+                    }
+                }
+            }";
+
+            var result = await server.RenderResult(queryContext);
+            CommonAssertions.AreEqualJsonStrings(expectedJson, result);
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
@@ -501,8 +501,8 @@ namespace GraphQL.AspNet.Tests.Execution
 
             var queryContext = server.CreateQueryContextBuilder();
             queryContext.AddQueryText(
-                @"mutation ($arg1: Guid){
-                    createWithModelGuidNullId(param: {id: $arg1})  {
+                @"mutation ($arg1: Input_ModelWithGuid){
+                    createWithModelGuidNullId(param: $arg1)  {
                        property1
                         property2
                     }
@@ -1041,7 +1041,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Messages[0].Code);
         }
 
         [Test]
@@ -1135,7 +1135,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.INVALID_VARIABLE_VALUE, result.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Messages[0].Code);
         }
 
         [Test]

--- a/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/VariableExecutionTests.cs
@@ -1041,7 +1041,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -1135,7 +1135,7 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.ExecuteQuery(queryContext);
             Assert.IsTrue(result.Messages.Severity.IsCritical());
             Assert.AreEqual(1, result.Messages.Count);
-            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT, result.Messages[0].Code);
+            Assert.AreEqual(Constants.ErrorCodes.INVALID_ARGUMENT_VALUE, result.Messages[0].Code);
         }
 
         [Test]
@@ -1154,8 +1154,7 @@ namespace GraphQL.AspNet.Tests.Execution
                     }
                 }");
 
-            // No Variable data is supplied for $arg1 meaning the default value of param
-            // should take effect
+            // Actual value supplied for arg1...should be used
             queryContext.AddVariableData(@"{ ""arg1"" : 2020 }");
 
             var expectedJson = @"

--- a/src/unit-tests/graphql-aspnet-tests/Execution/VariableKitchenSinkTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/VariableKitchenSinkTests.cs
@@ -282,7 +282,10 @@ namespace GraphQL.AspNet.Tests.Execution
 
                         ""veryDeepObject"" : {
                             ""dataField"": ""veryDeepObjectFieldValue"",
-                            ""dataObject"": null
+                            ""dataObject"": {
+                                ""dataField"" : ""veryVeryDeepObjectFieldValue"",
+                                ""dataObject"": null
+                            }
                         },
 
                         ""nullItem"": {
@@ -302,7 +305,10 @@ namespace GraphQL.AspNet.Tests.Execution
                               ""dataObject"": {
                                 ""dataField"": ""veryDeepFieldValue"",
                                 ""dataObject"": {
-                                  ""dataField"": ""veryDeepObjectFieldValue""
+                                  ""dataField"": ""veryDeepObjectFieldValue"",
+                                  ""dataObject"": {
+                                    ""dataField"" : ""veryVeryDeepObjectFieldValue"",
+                                  }
                                 }
                               }
                             }
@@ -535,6 +541,9 @@ namespace GraphQL.AspNet.Tests.Execution
                                         dataField
                                         dataObject {
                                             dataField
+                                            dataObject {
+                                                dataField
+                                            }
                                         }
                                     }
                                 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Variables/ResolvedVariableGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Variables/ResolvedVariableGeneratorTests.cs
@@ -24,7 +24,6 @@ namespace GraphQL.AspNet.Tests.Execution.Variables
     {
         private async Task<ResolvedVariableGenerator> CreateGenerator(string queryText)
         {
-
             var server = new TestServerBuilder()
                 .AddType<VariableTestController>()
                 .Build();

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Variables/ResolvedVariableTestData/VariableTestController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Variables/ResolvedVariableTestData/VariableTestController.cs
@@ -68,5 +68,17 @@ namespace GraphQL.AspNet.Tests.Execution.Variables.ResolvedVariableTestData
         {
             return null;
         }
+
+        [QueryRoot]
+        public string NonNullableIntValue(int arg1)
+        {
+            return null;
+        }
+
+        [QueryRoot]
+        public string NullableIntValue(int? arg1)
+        {
+            return null;
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/InputResolverGeneratorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/InputResolverGeneratorTests.cs
@@ -421,7 +421,7 @@ namespace GraphQL.AspNet.Tests.Internal
         }
 
         [Test]
-        public void InputObjectValueResolver_WhenNullPasssedToNonNullableAndRequiredField_ExecutionExceptionisThrown()
+        public void InputObjectValueResolver_WhenNullPasssedToNonNullableAndRequiredField_UnresolvedValueExceptionThrown()
         {
             var schema = this.CreateSchema();
             var obj = schema.KnownTypes.FindGraphType("Input_Telephone") as IInputObjectGraphType;
@@ -450,7 +450,7 @@ namespace GraphQL.AspNet.Tests.Internal
 
             var resolver = generator.CreateResolver(typeExpression);
 
-            Assert.Throws<GraphExecutionException>(() =>
+            Assert.Throws<UnresolvedValueException>(() =>
             {
                 var result = resolver.Resolve(complexObject);
             });

--- a/src/unit-tests/graphql-aspnet-tests/Internal/InputValueNodeTestData/Telephone.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/InputValueNodeTestData/Telephone.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.InputValueNodeTestData
+{
+    using System.ComponentModel.DataAnnotations;
+    using GraphQL.AspNet.Attributes;
+
+    public class Telephone
+    {
+        [Required]
+        [GraphField]
+        public int Id { get; set; }
+
+        [GraphField]
+        public string Brand { get; set; }
+    }
+}


### PR DESCRIPTION
* Fixed a bug where a required variable, when not supplied, would default to null instead of rendering an error message
* Fixed a bug with `InputObjectResolver` ; the resolver will now throw an `UnresolvedValueException` as expected when the value is not resolvable. (previously threw `GraphExecutionException`)
* Fixed a bug where a validation error would occur if an optional variable defined null as its default value when used against a non-nullable field that defined a default value.   The default value of the defined field will be used instead of null in this scenario, per the specification.
* Fixed a bug with the InputObjectResolver where, in some scenarios, when a required field on an input object was not provided it was simply ignored instead of raising an error.
* Added better error handling and messaging for field level issues related to explicitly provided null values to optional variables targeting non-nullable fields.
* Fixed a bug with the controller helper method `this.InternalServerError()`. It will now correctly report the error code `INTERNAL_SERVER_ERROR`. Previously it reported "unhandled exception".

# Other Changes
* Moved Default value generation to the field makers (previously part of the introspection system)