### PR TITLE
Issue with an unusable variable value not stopping field execution

### DIFF
--- a/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
+++ b/src/graphql-aspnet/Execution/ExecutionArgumentGenerator.cs
@@ -70,6 +70,7 @@ namespace GraphQL.AspNet.Execution
                               Constants.ErrorCodes.INVALID_ARGUMENT_VALUE,
                               arg.Origin);
 
+                            successful = false;
                             continue;
                         }
                     }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/Variables/InvokableVariableController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/Variables/InvokableVariableController.cs
@@ -1,0 +1,26 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.Variables
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class InvokableVariableController : GraphController
+    {
+        public int TotalInvocations { get; private set; }
+
+        [QueryRoot]
+        public int InvokeMethod(int param = 0)
+        {
+            this.TotalInvocations += 1;
+            return -1;
+        }
+    }
+}


### PR DESCRIPTION
* fixed a bug with an unusable variable value (to an argument) not stopping field execution. Field execution will now correctly halt field resolution.