### PR TITLE
Fixed a bug with not supplied, nullable arguments and input fields

### DIFF
--- a/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
+++ b/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
@@ -40,9 +40,6 @@ namespace GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.Field
                 if (argument.ArgumentModifiers.IsInternalParameter())
                     continue;
 
-                // when the argument is required but the schema defines no value
-                // and it was not on the user query document this rule fails
-
                 if (argument.IsRequired &&
                     !suppliedArguments.ContainsKey(argument.Name.AsMemory()))
                 {

--- a/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
+++ b/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnField.cs
@@ -42,8 +42,8 @@ namespace GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.Field
 
                 // when the argument is required but the schema defines no value
                 // and it was not on the user query document this rule fails
-                if (argument.TypeExpression.IsNonNullable &&
-                    argument.DefaultValue == null &&
+
+                if (argument.IsRequired &&
                     !suppliedArguments.ContainsKey(argument.Name.AsMemory()))
                 {
                     this.ValidationError(

--- a/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
+++ b/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/QueryDirectiveSteps/Rule_5_4_2_1_RequiredArgumentMustBeSuppliedOrHaveDefaultValueOnDirective.cs
@@ -45,7 +45,7 @@ namespace GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.Query
                     if (argument.ArgumentModifiers.IsInternalParameter())
                         continue;
 
-                    if (argument.DefaultValue == null && !suppliedArgs.ContainsKey(argument.Name.AsMemory()))
+                    if (argument.IsRequired && !suppliedArgs.ContainsKey(argument.Name.AsMemory()))
                     {
                         this.ValidationError(
                             context,

--- a/src/graphql-aspnet/Interfaces/Schema/IDefaultValueSchemaItem.cs
+++ b/src/graphql-aspnet/Interfaces/Schema/IDefaultValueSchemaItem.cs
@@ -10,7 +10,7 @@
 namespace GraphQL.AspNet.Interfaces.Schema
 {
     /// <summary>
-    /// A schema item that defines an optional default value.
+    /// A schema item that may define a default value.
     /// </summary>
     public interface IDefaultValueSchemaItem : ISchemaItem
     {

--- a/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
@@ -132,10 +132,9 @@ namespace GraphQL.AspNet.Internal.Resolvers
             // ideally this is handled by the request pipeline and validation middleware
             // but since the developer can change such things we do a quick sanity check
             // here and raise a helpful exception instead of something random later
+            // as the value cannot be used to resolve a field in such a state
             foreach (var field in _graphType.Fields.RequiredFields)
             {
-                // if a non-nullable field was supplied on the request
-                // then all is god
                 if (suppliedFields != null && suppliedFields.TryGetField(field.Name, out _))
                     continue;
 
@@ -150,7 +149,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
 
                 throw new GraphExecutionException(
                     $"Unable to resolve type '{_graphType.Name}'. Field " +
-                    $"'{field.Name}' was not supplied but is non-nullable " +
+                    $"'{field.Name}' was not supplied on the query but is non-nullable " +
                     $"and has no default value.",
                     origin);
             }

--- a/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputObjectValueResolver.cs
@@ -129,38 +129,30 @@ namespace GraphQL.AspNet.Internal.Resolvers
 
             // check all the fields that "must have a value"
             // to ensure they are put on the input object being constructed
-            foreach (var field in _graphType.Fields.NonNullableFields)
+            // ideally this is handled by the request pipeline and validation middleware
+            // but since the developer can change such things we do a quick sanity check
+            // here and raise a helpful exception instead of something random later
+            foreach (var field in _graphType.Fields.RequiredFields)
             {
                 // if a non-nullable field was supplied on the request
-                // and processed successfully then skip it
+                // then all is god
                 if (suppliedFields != null && suppliedFields.TryGetField(field.Name, out _))
                     continue;
 
-                if (field.IsRequired)
+                // the document validation rules
+                // should prevent this scenario from ever happening
+                // but trap it just in case to give a helpful exception
+                SourceOrigin origin = default;
+                if (resolvableItem is IDocumentPart docPart)
                 {
-                    // the document validation rules
-                    // should prevent this scenario from ever happening
-                    // but trap it just in case to give a helpful exception
-                    SourceOrigin origin = default;
-                    if (resolvableItem is IDocumentPart docPart)
-                    {
-                        origin = docPart.SourceLocation.AsOrigin();
-                    }
-
-                    throw new GraphExecutionException(
-                        $"Unable to resolve type '{_graphType.Name}'. Field " +
-                        $"'{field.Name}' was not supplied but is non-nullable " +
-                        $"and has no default value.",
-                        origin);
+                    origin = docPart.SourceLocation.AsOrigin();
                 }
 
-                var propSetter = _propSetters.ContainsKey(field.InternalName) ? _propSetters[field.InternalName] : null;
-                var resolver = _fieldResolvers.ContainsKey(field.Name) ? _fieldResolvers[field.Name] : null;
-                if (resolver == null || propSetter == null)
-                    continue;
-
-                var resolvedValue = resolver.Resolve(DefaultInputObjectResolutionValue.Instance);
-                propSetter(ref instance, resolvedValue);
+                throw new GraphExecutionException(
+                    $"Unable to resolve type '{_graphType.Name}'. Field " +
+                    $"'{field.Name}' was not supplied but is non-nullable " +
+                    $"and has no default value.",
+                    origin);
             }
 
             return instance;

--- a/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputValueResolverBase.cs
@@ -9,10 +9,6 @@
 
 namespace GraphQL.AspNet.Internal.Resolvers
 {
-    using System;
-    using GraphQL.AspNet.Execution.Exceptions;
-    using GraphQL.AspNet.Execution.Source;
-    using GraphQL.AspNet.Interfaces.Execution.QueryPlans.DocumentParts;
     using GraphQL.AspNet.Interfaces.Execution.QueryPlans.Resolvables;
     using GraphQL.AspNet.Interfaces.Execution.Variables;
     using GraphQL.AspNet.Interfaces.Schema;

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
@@ -48,7 +48,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
                 context.FieldResults.Count == 0 ||
                 context.FieldResults.All(x => x.Status != FieldDataItemResolutionStatus.Complete))
             {
-                // rule 6.4.4 if any top level field is nulled out or otherwise
+                // rule 6.4.4 if all top level fields are nulled out or otherwise
                 // made into an error state because of an error it caused or one of its child
                 // fields caused then null out the "data" field entirely
                 return null;

--- a/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/QueryExecution/Components/PackageQueryResultMiddleware.cs
@@ -9,11 +9,13 @@
 
 namespace GraphQL.AspNet.Middleware.QueryExecution.Components
 {
+    using System;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Execution;
     using GraphQL.AspNet.Execution.Contexts;
+    using GraphQL.AspNet.Execution.FieldResolution;
     using GraphQL.AspNet.Execution.Response;
     using GraphQL.AspNet.Interfaces.Execution.Response;
     using GraphQL.AspNet.Interfaces.Middleware;
@@ -27,11 +29,7 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
         public Task InvokeAsync(QueryExecutionContext context, GraphMiddlewareInvocationDelegate<QueryExecutionContext> next, CancellationToken cancelToken)
         {
             // create and attach the result
-            IQueryResponseFieldSet fieldSet = null;
-            if (context.FieldResults != null && context.FieldResults.Any())
-            {
-                fieldSet = this.CreateFinalDictionary(context);
-            }
+            this.CreateFinalDictionary(context, out var fieldSet);
 
             context.Result = new QueryExecutionResult(context.QueryRequest, context.Messages, fieldSet, context.Metrics);
             context.Logger?.RequestCompleted(context);
@@ -43,21 +41,41 @@ namespace GraphQL.AspNet.Middleware.QueryExecution.Components
         /// to be returned as the graph projection. Takes care of an final messaging in case one of the tasks failed.
         /// </summary>
         /// <param name="context">The execution context to extract reponse info from.</param>
-        /// <returns>GraphQL.AspNet.Interfaces.Response.IResponseFieldSet.</returns>
-        private IQueryResponseFieldSet CreateFinalDictionary(QueryExecutionContext context)
+        /// <param name="fieldSet">This parameter will be filled with the results of the dictionary creation
+        /// operation.</param>
+        private void CreateFinalDictionary(QueryExecutionContext context, out IQueryResponseFieldSet fieldSet)
         {
-            var topFieldResponses = new ResponseFieldSet();
+            fieldSet = null;
+
+            if (context.FieldResults == null ||
+                context.FieldResults.Count == 0 ||
+                context.FieldResults.All(x => x.Status != FieldDataItemResolutionStatus.Complete))
+            {
+                // rule 6.4.4 if any top level field is nulled out or otherwise
+                // made into an error state because of an error it caused or one of its child
+                // fields caused then null out the "data" field entirely
+                return;
+            }
+
+            var response = new ResponseFieldSet();
+            var atLeastOneFieldGenerated = false;
             foreach (var fieldResult in context.FieldResults)
             {
                 var generated = fieldResult.GenerateResult(out var result);
                 if (generated)
-                    topFieldResponses.Add(fieldResult.Name, result);
+                {
+                    atLeastOneFieldGenerated = true;
+                    response.Add(fieldResult.Name, result);
+                }
             }
 
-            if (topFieldResponses.Fields.Count == 0 || topFieldResponses.Fields.All(x => x.Value == null))
-                topFieldResponses = null;
-
-            return topFieldResponses;
+            // some fields in the response set may not generate final data
+            // and are acceptable to be dropped. For instance when resolving a top-level field
+            // that returns a union and the spread of union types in teh query does not included a projection of
+            // the actual data items returned. (i.e. spread on ObjectA, but only items of ObjectB were resolved
+            // from the field)
+            if (atLeastOneFieldGenerated)
+                fieldSet = response;
         }
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
@@ -17,9 +17,10 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
     using GraphQL.AspNet.Schemas.Structural;
 
     /// <summary>
-    /// An argument defined on the object graph but not tied to any concrete item. It exists as a result
-    /// of a programatic delcaration. The parameters of action methods on <see cref="GraphController"/> are generally mapped
-    /// into a <see cref="GraphFieldArgument"/> for purposes of mapping, data coersion and introspection.
+    /// An argument defined on the object graph. This object is created as a result
+    /// of a programatic delcaration. The parameters of action methods on <see cref="GraphController"/> and methods
+    /// registered as fields on POCOs are generally mapped into a <see cref="GraphFieldArgument"/> for purposes of mapping,
+    /// data coersion and introspection.
     /// </summary>
     [DebuggerDisplay("Argument: {Name}")]
     public class GraphFieldArgument : IGraphArgument
@@ -63,7 +64,11 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
             this.TypeExpression = Validation.ThrowIfNullOrReturn(typeExpression, nameof(typeExpression));
             this.ObjectType = Validation.ThrowIfNullOrReturn(objectType, nameof(objectType));
             this.ArgumentModifiers = modifiers;
-            this.HasDefaultValue = hasDefaultValue || this.TypeExpression.IsNullable;
+
+            // by definition (rule 5.4.2.1) a nullable type expression on an argument implies
+            // an optional field. that is to say it has an implicit default value of 'null'
+            this.HasDefaultValue = hasDefaultValue;
+            this.IsRequired = !hasDefaultValue && this.TypeExpression.IsNonNullable;
             this.DefaultValue = defaultValue;
             this.Description = description?.Trim();
 
@@ -126,6 +131,6 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public ISchemaItem Parent { get; }
 
         /// <inheritdoc />
-        public bool IsRequired => !this.HasDefaultValue && this.TypeExpression.IsNonNullable;
+        public bool IsRequired { get; }
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/GraphFieldArgument.cs
@@ -63,7 +63,7 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
             this.TypeExpression = Validation.ThrowIfNullOrReturn(typeExpression, nameof(typeExpression));
             this.ObjectType = Validation.ThrowIfNullOrReturn(objectType, nameof(objectType));
             this.ArgumentModifiers = modifiers;
-            this.HasDefaultValue = hasDefaultValue;
+            this.HasDefaultValue = hasDefaultValue || this.TypeExpression.IsNullable;
             this.DefaultValue = defaultValue;
             this.Description = description?.Trim();
 
@@ -126,6 +126,6 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public ISchemaItem Parent { get; }
 
         /// <inheritdoc />
-        public bool IsRequired => !this.HasDefaultValue;
+        public bool IsRequired => !this.HasDefaultValue && this.TypeExpression.IsNonNullable;
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/InputGraphField.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/InputGraphField.cs
@@ -22,6 +22,16 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
     [DebuggerDisplay("Field: {Route.Path}")]
     public class InputGraphField : IInputGraphField
     {
+        // *******************************************
+        // implementation note:
+        //
+        // IsRequired here deviates from the input object field template (which keys off the [Required]
+        // attribute).
+        //
+        // by definition (rule 5.6.4) a field is required if it is non-null and does not have a default value.
+        // which is to say that all nullable fields are "not required" by the schema definition
+        // *******************************************
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InputGraphField" /> class.
         /// </summary>
@@ -31,7 +41,9 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         /// <param name="declaredPropertyName">The name of the property as it was declared on a <see cref="Type" /> (its internal name).</param>
         /// <param name="objectType">The .NET type of the item or items that represent the graph type returned by this field.</param>
         /// <param name="declaredReturnType">The .NET type as it was declared on the property which generated this field..</param>
-        /// <param name="isRequired">if set to <c>true</c> this field was explicitly marked as being required.</param>
+        /// <param name="isRequired">if set to <c>true</c> this field was explicitly marked as being required being it has no
+        /// explicitly declared default value. The value passsed on <paramref name="defaultValue"/> will be ignored. Note that
+        /// the field will only truely be marked as required if it is has a non-nullable type expression.</param>
         /// <param name="defaultValue">When <paramref name="isRequired"/> is <c>false</c>, represents
         /// the value that should be used for this field when its not declared on a query document.</param>
         /// <param name="directives">The directives to apply to this field when its added to a schema.</param>
@@ -57,7 +69,8 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
 
             this.InternalName = declaredPropertyName;
             this.HasDefaultValue = !isRequired;
-            this.DefaultValue = this.HasDefaultValue ? defaultValue : null;
+            this.IsRequired = isRequired && this.TypeExpression.IsNonNullable;
+            this.DefaultValue = defaultValue;
             this.Publish = true;
         }
 
@@ -109,6 +122,6 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
         public bool HasDefaultValue { get; }
 
         /// <inheritdoc />
-        public bool IsRequired => !this.HasDefaultValue;
+        public bool IsRequired { get; }
     }
 }

--- a/src/graphql-aspnet/Schemas/TypeSystem/VirtualGraphFieldArgument.cs
+++ b/src/graphql-aspnet/Schemas/TypeSystem/VirtualGraphFieldArgument.cs
@@ -54,7 +54,10 @@ namespace GraphQL.AspNet.Schemas.TypeSystem
             this.ParameterName = this.Name;
             this.TypeExpression = Validation.ThrowIfNullOrReturn(typeExpression, nameof(typeExpression));
             this.ArgumentModifiers = argModifiers;
-            this.HasDefaultValue = hasDefaultValue;
+
+            // by definition (rule 5.4.2.1) a nullable type expression on an argument implies
+            // an optional field. that is to say it has an implicit default value of 'null'
+            this.HasDefaultValue = hasDefaultValue || this.TypeExpression.IsNullable;
             this.DefaultValue = defaultValue;
 
             this.AppliedDirectives = new AppliedDirectiveCollection(this);

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/FieldMaker_InputFieldTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/FieldMaker_InputFieldTests.cs
@@ -109,7 +109,9 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
             var graphField = new GraphFieldMaker(server.Schema).CreateField(fieldTemplate).Field;
 
             Assert.AreEqual("requiredReferenceTypeField", graphField.Name);
-            Assert.IsTrue((bool)graphField.IsRequired);
+
+            // a nullable type expression can never be "required"
+            Assert.IsFalse((bool)graphField.IsRequired);
 
             // because its marked as required, even though its a reference type (which is nullable)
             // the type expression is automatically hoisted to be "non-nullable"

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
@@ -493,5 +493,31 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
         }
+
+        [TestCase(
+            @" query { receiveNullableObject }",
+            @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveObjectWithDefaultValue }",
+            @"{ ""data"": { ""receiveObjectWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableObject }",
+            @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableObjectWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableObjectWithDefaultValue"": ""object null"" } }")]
+        public async Task InputObject_DefaultValueTests(string query, string expectedResults)
+        {
+            var server = new TestServerBuilder()
+                .AddGraphController<RequiredInputObjectTestController>()
+                .Build();
+
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText(query);
+            var result = await server.RenderResult(builder);
+
+            CommonAssertions.AreEqualJsonStrings(expectedResults, result);
+
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
@@ -495,6 +495,19 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [TestCase(
+            @" query { receiveNullableEnum }",
+            @"{ ""data"": { ""receiveNullableEnum"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""object supplied"" } }")]
+
+        [TestCase(
+            @" query { receiveNullableInt }",
+            @"{ ""data"": { ""receiveNullableInt"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""object supplied"" } }")]
+        [TestCase(
             @" query { receiveNullableObject }",
             @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
         [TestCase(
@@ -506,10 +519,10 @@ namespace GraphQL.AspNet.Tests.Execution
         [TestCase(
             @" query { receiveNullableObjectWithDefaultValue }",
             @"{ ""data"": { ""receiveNullableObjectWithDefaultValue"": ""object null"" } }")]
-        public async Task InputObject_DefaultValueTests(string query, string expectedResults)
+        public async Task NullableFieldArgument_DefaultValueTests(string query, string expectedResults)
         {
             var server = new TestServerBuilder()
-                .AddGraphController<RequiredInputObjectTestController>()
+                .AddGraphController<NullableFieldArgumentTestController>()
                 .Build();
 
             var builder = server.CreateQueryContextBuilder()
@@ -517,7 +530,6 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
 
             CommonAssertions.AreEqualJsonStrings(expectedResults, result);
-
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests2.cs
@@ -495,34 +495,148 @@ namespace GraphQL.AspNet.Tests.Execution
         }
 
         [TestCase(
-            @" query { receiveNullableEnum }",
-            @"{ ""data"": { ""receiveNullableEnum"": ""object null"" } }")]
-        [TestCase(
-            @" query { receiveNullableEnumWithDefaultValue }",
-            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""object supplied"" } }")]
-
-        [TestCase(
             @" query { receiveNullableInt }",
             @"{ ""data"": { ""receiveNullableInt"": ""object null"" } }")]
         [TestCase(
+            @" query { receiveNullableInt(obj: null) }",
+            @"{ ""data"": { ""receiveNullableInt"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableInt(obj: 1) }",
+            @"{ ""data"": { ""receiveNullableInt"": ""object supplied"" } }")]
+        [TestCase(
             @" query { receiveNullableIntWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue(obj: null) }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue(obj: 1) }",
             @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""object supplied"" } }")]
         [TestCase(
-            @" query { receiveNullableObject }",
-            @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
+            @" query { receiveNullableEnum }",
+            @"{ ""data"": { ""receiveNullableEnum"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnum(obj: null) }",
+            @"{ ""data"": { ""receiveNullableEnum"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnum(obj: VALUE1) }",
+            @"{ ""data"": { ""receiveNullableEnum"": ""object supplied"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue(obj: null) }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue(obj: VALUE1) }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""object supplied"" } }")]
+        [TestCase(
+            @" query { receiveObject }",
+            @"{ ""data"": { ""receiveObject"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveObject(obj: null) }",
+            @"{ ""data"": { ""receiveObject"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveObject(obj: {}) }",
+            @"{ ""data"": { ""receiveObject"": ""object supplied"" } }")]
         [TestCase(
             @" query { receiveObjectWithDefaultValue }",
             @"{ ""data"": { ""receiveObjectWithDefaultValue"": ""object null"" } }")]
         [TestCase(
+            @" query { receiveObjectWithDefaultValue(obj: null) }",
+            @"{ ""data"": { ""receiveObjectWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveObjectWithDefaultValue(obj: {}) }",
+            @"{ ""data"": { ""receiveObjectWithDefaultValue"": ""object supplied"" } }")]
+        [TestCase(
             @" query { receiveNullableObject }",
             @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
         [TestCase(
+            @" query { receiveNullableObject(obj: null) }",
+            @"{ ""data"": { ""receiveNullableObject"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableObject(obj: {}) }",
+            @"{ ""data"": { ""receiveNullableObject"": ""object supplied"" } }")]
+        [TestCase(
             @" query { receiveNullableObjectWithDefaultValue }",
             @"{ ""data"": { ""receiveNullableObjectWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableObjectWithDefaultValue(obj: null) }",
+            @"{ ""data"": { ""receiveNullableObjectWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableObjectWithDefaultValue(obj: {}) }",
+            @"{ ""data"": { ""receiveNullableObjectWithDefaultValue"": ""object supplied"" } }")]
+        [TestCase(
+            @" query { receiveNullableStruct }",
+            @"{ ""data"": { ""receiveNullableStruct"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableStruct(obj: null) }",
+            @"{ ""data"": { ""receiveNullableStruct"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableStruct(obj: {field1: ""bob""}) }",
+            @"{ ""data"": { ""receiveNullableStruct"": ""object supplied"" } }")]
+        [TestCase(
+            @" query { receiveNullableStructWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableStructWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableStructWithDefaultValue(obj: null) }",
+            @"{ ""data"": { ""receiveNullableStructWithDefaultValue"": ""object null"" } }")]
+        [TestCase(
+            @" query { receiveNullableStructWithDefaultValue(obj: {field1: ""bob""}) }",
+            @"{ ""data"": { ""receiveNullableStructWithDefaultValue"": ""object supplied"" } }")]
         public async Task NullableFieldArgument_DefaultValueTests(string query, string expectedResults)
         {
             var server = new TestServerBuilder()
                 .AddGraphController<NullableFieldArgumentTestController>()
+                .Build();
+
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText(query);
+            var result = await server.RenderResult(builder);
+
+            CommonAssertions.AreEqualJsonStrings(expectedResults, result);
+        }
+
+        [TestCase(
+            @" query { receiveNullableInt }",
+            @"{ ""data"": { ""receiveNullableInt"": null } }")]
+        [TestCase(
+            @" query { receiveNullableInt(obj:null) }",
+            @"{ ""data"": { ""receiveNullableInt"": null } }")]
+        [TestCase(
+            @" query { receiveNullableInt(obj: 3) }",
+            @"{ ""data"": { ""receiveNullableInt"": ""3"" } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""5"" } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue(obj:null) }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": null } }")]
+        [TestCase(
+            @" query { receiveNullableIntWithDefaultValue(obj: 3) }",
+            @"{ ""data"": { ""receiveNullableIntWithDefaultValue"": ""3"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnum }",
+            @"{ ""data"": { ""receiveNullableEnum"": null } }")]
+        [TestCase(
+            @" query { receiveNullableEnum(obj:null) }",
+            @"{ ""data"": { ""receiveNullableEnum"": null } }")]
+        [TestCase(
+            @" query { receiveNullableEnum(obj: VALUE1) }",
+            @"{ ""data"": { ""receiveNullableEnum"": ""Value1"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""Value2"" } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue(obj:null) }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": null } }")]
+        [TestCase(
+            @" query { receiveNullableEnumWithDefaultValue(obj: VALUE1) }",
+            @"{ ""data"": { ""receiveNullableEnumWithDefaultValue"": ""Value1"" } }")]
+        public async Task NullableFieldArgument_NonNullDefaultValueTests(string query, string expectedResults)
+        {
+            var server = new TestServerBuilder()
+                .AddGraphController<DefaultValueCheckerController>()
                 .Build();
 
             var builder = server.CreateQueryContextBuilder()

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DirectiveTestData/ObjectTypeDirectiveWithParams.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DirectiveTestData/ObjectTypeDirectiveWithParams.cs
@@ -16,7 +16,7 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine.DirectiveTestData
     public class ObjectTypeDirectiveWithParams : GraphDirective
     {
         [DirectiveLocations(DirectiveLocation.OBJECT)]
-        public IGraphActionResult DoThing(int arg1, string arg2)
+        public IGraphActionResult DoThing(int arg1, [FromGraphQL(TypeExpression = "Type!")] string arg2)
         {
             return this.Ok();
         }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
@@ -39,6 +39,7 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             QueriesToFail = new List<object>();
             QueriesToPass = new List<object>();
 
+
             // no such operation type as 'fakeOperationType'
             AddQueryFailure("5.1.1", "fakeOperationType Operation1{ peopleMovers { elevator(id: 5){id, name} } }");
 
@@ -134,6 +135,13 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
 
             // required argument must be provided ("someValue" required on @Restrict but not provided)
             AddQueryFailure("5.4.2.1", "query Operation1{ peopleMovers @restrict { elevator (id: 5) { id name } } }");
+
+            // argument "e" representing ElevatorBindingModel is "nullable" on the "matchElevator" field
+            // and was not supplied. This is allowed, e should be interpreted as null
+            AddQuerySuccess("5.4.2.1", "query Operation1{ peopleMovers { matchElevator { id name } } }");
+
+            // argument "e" representing ElevatorBindingModel can be supplied as null
+            AddQuerySuccess("5.4.2.1", "query Operation1{ peopleMovers { matchElevator(e: null) { id name } } }");
 
             // named fragments must be unique
             AddQueryFailure("5.5.1.1", "query Operation1{ peopleMovers { elevator(id: 5){ ...frag1  } } } fragment frag1 on Elevator { id } fragment frag1 on Elevator { name} ");

--- a/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/RulesEngine/DocumentValidationRuleProcessorTests.cs
@@ -39,7 +39,6 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             QueriesToFail = new List<object>();
             QueriesToPass = new List<object>();
 
-
             // no such operation type as 'fakeOperationType'
             AddQueryFailure("5.1.1", "fakeOperationType Operation1{ peopleMovers { elevator(id: 5){id, name} } }");
 
@@ -136,8 +135,8 @@ namespace GraphQL.AspNet.Tests.Execution.RulesEngine
             // required argument must be provided ("someValue" required on @Restrict but not provided)
             AddQueryFailure("5.4.2.1", "query Operation1{ peopleMovers @restrict { elevator (id: 5) { id name } } }");
 
-            // argument "e" representing ElevatorBindingModel is "nullable" on the "matchElevator" field
-            // and was not supplied. This is allowed, e should be interpreted as null
+            // argument "e" representing ElevatorBindingModel is nullable on the "matchElevator" field
+            // and was not supplied. This is allowed, "e" should be interpreted as null
             AddQuerySuccess("5.4.2.1", "query Operation1{ peopleMovers { matchElevator { id name } } }");
 
             // argument "e" representing ElevatorBindingModel can be supplied as null

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/DefaultValueCheckerController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/DefaultValueCheckerController.cs
@@ -1,0 +1,59 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class DefaultValueCheckerController : GraphController
+    {
+        public enum TestEnum
+        {
+            Value1,
+            Value2,
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableInt(int? obj)
+        {
+            if (!obj.HasValue)
+                return null;
+
+            return obj.Value.ToString();
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableIntWithDefaultValue(int? obj = 5)
+        {
+            if (!obj.HasValue)
+                return null;
+
+            return obj.Value.ToString();
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableEnum(TestEnum? obj)
+        {
+            if (!obj.HasValue)
+                return null;
+
+            return obj.Value.ToString();
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableEnumWithDefaultValue(TestEnum? obj = TestEnum.Value2)
+        {
+            if (!obj.HasValue)
+                return null;
+
+            return obj.Value.ToString();
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/InputObjStruct.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/InputObjStruct.cs
@@ -1,0 +1,16 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    public struct InputObjStruct
+    {
+        public string Field1 { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/NullableFieldArgumentTestController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/NullableFieldArgumentTestController.cs
@@ -12,8 +12,38 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Tests.Framework.CommonHelpers;
 
-    public class RequiredInputObjectTestController : GraphIdController
+    public class NullableFieldArgumentTestController : GraphIdController
     {
+        public enum TestEnum
+        {
+            Value1,
+            Value2,
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableEnum(TestEnum? obj)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableEnumWithDefaultValue(TestEnum? obj = TestEnum.Value1)
+        {
+            return obj.HasValue && obj == TestEnum.Value1 ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableInt(TestEnum? obj)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableIntWithDefaultValue(int? obj = 3)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
+
         [QueryRoot]
         public string ReceiveObject(TwoPropertyObject obj)
         {

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/NullableFieldArgumentTestController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/NullableFieldArgumentTestController.cs
@@ -27,19 +27,19 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
         }
 
         [QueryRoot]
-        public string ReceiveNullableEnumWithDefaultValue(TestEnum? obj = TestEnum.Value1)
-        {
-            return obj.HasValue && obj == TestEnum.Value1 ? "object supplied" : "object null";
-        }
-
-        [QueryRoot]
-        public string ReceiveNullableInt(TestEnum? obj)
+        public string ReceiveNullableEnumWithDefaultValue(TestEnum? obj = null)
         {
             return obj.HasValue ? "object supplied" : "object null";
         }
 
         [QueryRoot]
-        public string ReceiveNullableIntWithDefaultValue(int? obj = 3)
+        public string ReceiveNullableInt(int? obj)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableIntWithDefaultValue(int? obj = null)
         {
             return obj.HasValue ? "object supplied" : "object null";
         }
@@ -69,5 +69,17 @@ namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
             return obj != null ? "object supplied" : "object null";
         }
 #nullable disable
+
+        [QueryRoot]
+        public string ReceiveNullableStruct(InputObjStruct? obj)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableStructWithDefaultValue(InputObjStruct? obj = null)
+        {
+            return obj.HasValue ? "object supplied" : "object null";
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/RequiredInputObjectTestController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/RequiredInputObjectTestController.cs
@@ -1,0 +1,43 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class RequiredInputObjectTestController : GraphIdController
+    {
+        [QueryRoot]
+        public string ReceiveObject(TwoPropertyObject obj)
+        {
+            return obj != null ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveObjectWithDefaultValue(TwoPropertyObject obj = null)
+        {
+            return obj != null ? "object supplied" : "object null";
+        }
+
+#nullable enable
+        [QueryRoot]
+        public string ReceiveNullableObject(TwoPropertyObject? obj)
+        {
+            return obj != null ? "object supplied" : "object null";
+        }
+
+        [QueryRoot]
+        public string ReceiveNullableObjectWithDefaultValue(TwoPropertyObject? obj = null)
+        {
+            return obj != null ? "object supplied" : "object null";
+        }
+#nullable disable
+    }
+}


### PR DESCRIPTION
* Fixed a bug where by when a nullable argument on a field, without a default value, is omitted from a query a `KeyNotFoundException` was being thrown instead of properly applying a null value for the argument (per rule 5.4.2.1)

* Fixed a bug where by when a nullable input object field, without a default value, is omitted on a query it resulted in a `KeyNotFoundException` being thrown instead of properly applying a null value for the input field (per rule 5.6.4)

* Fixed a bug where by an optional, nullable scalar field, without an explicitly declared default value, on an input object, would cause an `UnresolvedValueException` if not supplied on a query. The value `null` will now be correctly applied to the field.

* Fixed a bug with introspection data for `__InputValue` type. A `"null"` default value should not longer be returned unless the supplying argument or input object field  explicitly declares `null` as the default value.

* Fixed a bug where by if all top level field results of a query were null, the `data` parameter of the result was automatically nulled out as well. The `data` object will now contain approrpiate entries for top level fields when all fields are null and null is allowed in all fields. If a top level field errors then the data object will still be nulled out per the specification (rule 6.4.4).