### PR TITLE
Fixed an issue with the developer items collection linkage between request and query context

### DIFF
--- a/src/graphql-aspnet/Engine/DefaultGraphQLRuntime.cs
+++ b/src/graphql-aspnet/Engine/DefaultGraphQLRuntime.cs
@@ -120,7 +120,7 @@ namespace GraphQL.AspNet.Engine
                 request,
                 serviceProvider,
                 session,
-                items: new MetaDataCollection(),
+                items: request.Items ?? new MetaDataCollection(),
                 securityContext: securityContext,
                 metrics: metricsPackage,
                 logger: _logger);

--- a/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/PipelineContextBuilders/QueryContextBuilder.cs
@@ -37,6 +37,7 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         private IUserSecurityContext _userSecurityContext;
         private IQueryExecutionMetrics _metrics;
         private IGraphEventLogger _eventLogger;
+        private MetaDataCollection _items;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryContextBuilder" /> class.
@@ -49,7 +50,10 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
         {
             _serviceProvider = Validation.ThrowIfNullOrReturn(serviceProvider, nameof(serviceProvider));
             _userSecurityContext = userSecurityContext;
+
+            _items = new MetaDataCollection();
             _mockRequest = new Mock<IQueryExecutionRequest>();
+            _mockRequest.Setup(x => x.Items).Returns(_items);
             _sourceData = new List<KeyValuePair<SchemaItemPath, object>>();
         }
 
@@ -142,18 +146,13 @@ namespace GraphQL.AspNet.Tests.Framework.PipelineContextBuilders
             var startDate = DateTimeOffset.UtcNow;
             _mockRequest.Setup(x => x.StartTimeUTC).Returns(startDate);
 
-            var metaData = new MetaDataCollection();
-
-            // unchangable items about the request
-            var request = new Mock<IQueryExecutionRequest>();
-            request.Setup(x => x.Items).Returns(metaData);
-
             // updateable items about the request
             var context = new QueryExecutionContext(
                 this.QueryRequest,
                 _serviceProvider,
                 new QuerySession(),
                 securityContext: _userSecurityContext,
+                items: this.QueryRequest.Items,
                 metrics: _metrics,
                 logger: _eventLogger);
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GeneralQueryExecutionTests.cs
@@ -956,5 +956,32 @@ namespace GraphQL.AspNet.Tests.Execution
             var result = await server.RenderResult(builder);
             CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
         }
+
+        [Test]
+        public async Task ExternalItem_InjectedIntoContextItemsCollection_MakesItToController()
+        {
+            var server = new TestServerBuilder()
+                 .AddType<ExternalItemCollectionController>()
+                 .Build();
+
+            var context = server.CreateQueryContextBuilder()
+                .AddQueryText("query { itemPassed }")
+                .Build();
+
+            context.Items.Add("test-key", new TwoPropertyObject()
+            {
+                Property2 = 5,
+            });
+
+            var expectedOutput =
+                @"{
+                    ""data"": {
+                       ""itemPassed"" : 5
+                     }
+                  }";
+
+            var result = await server.RenderResult(context);
+            CommonAssertions.AreEqualJsonStrings(expectedOutput, result);
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/ExternalItemCollectionController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/ExternalItemCollectionController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ExternalItemCollectionController : GraphController
+    {
+        [QueryRoot]
+        public int ItemPassed()
+        {
+            if (this.Request.Items != null && this.Request.Items.ContainsKey("test-key") && this.Request.Items["test-key"] is TwoPropertyObject item)
+            {
+                return item.Property2;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Web/WebTestData/ExternalItemCollectionController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Web/WebTestData/ExternalItemCollectionController.cs
@@ -1,0 +1,29 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Web.WebTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ExternalItemCollectionController : GraphController
+    {
+        [QueryRoot]
+        public int ItemPassed()
+        {
+            if (this.Request.Items != null && this.Request.Items.ContainsKey("test-key") && this.Request.Items["test-key"] is TwoPropertyObject item)
+            {
+                return item.Property2;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Web/WebTestData/ItemInjectorHttpProcessor.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Web/WebTestData/ItemInjectorHttpProcessor.cs
@@ -1,0 +1,40 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Web.WebTestData
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using GraphQL.AspNet;
+    using GraphQL.AspNet.Engine;
+    using GraphQL.AspNet.Interfaces.Engine;
+    using GraphQL.AspNet.Interfaces.Execution;
+    using GraphQL.AspNet.Interfaces.Logging;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ItemInjectorHttpProcessor : DefaultGraphQLHttpProcessor<GraphSchema>
+    {
+        public ItemInjectorHttpProcessor(GraphSchema schema, IGraphQLRuntime<GraphSchema> runtime, IQueryResponseWriter<GraphSchema> writer, IGraphEventLogger logger = null)
+            : base(schema, runtime, writer, logger)
+        {
+        }
+
+        protected override async Task<IQueryExecutionRequest> CreateQueryRequestAsync(GraphQueryData queryData, CancellationToken cancelToken = default)
+        {
+            var request = await base.CreateQueryRequestAsync(queryData, cancelToken);
+            request.Items.Add("test-key", new TwoPropertyObject()
+            {
+                Property2 = 3,
+            });
+
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
* Fixed a bug where by the developer driven items collection on the primary query request was not properly linked to the `QueryExecutionContext` and thus items added to one collection or the other may not be carried forward to the field resolutions depending on when and where the addition was made.  Items added to either collection, at any time, will now be carried forward to the field resolves as expected.

* Fixed the query context builder on the `TestServer` to use the proper mock request.