### PR TITLE
Dependency Updates

### DIFF
--- a/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
+++ b/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
@@ -21,7 +21,9 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
+++ b/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
+++ b/src/graphql-aspnet-subscriptions/graphql-aspnet-subscriptions.csproj
@@ -21,7 +21,9 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+
+    <!-- Transitive package increments to account for MS reported vulnerabilities -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/graphql-aspnet/graphql-aspnet.csproj
+++ b/src/graphql-aspnet/graphql-aspnet.csproj
@@ -21,8 +21,9 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
-
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/graphql-aspnet/graphql-aspnet.csproj
+++ b/src/graphql-aspnet/graphql-aspnet.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
 
   </ItemGroup>
 

--- a/src/graphql-aspnet/graphql-aspnet.csproj
+++ b/src/graphql-aspnet/graphql-aspnet.csproj
@@ -21,7 +21,9 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+
+    <!-- Transitive package increments to account for MS reported vulnerabilities -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
* Upped the minimum allowed package references for a few packages

System.Text.Encodings.Web => `4.7.2`
System.Drawing.Common => `4.7.2`
System.Text.RegularExpressions => `4.3.1`

_These packages are not directly needed by the library but are referenced to resolve reported security vulnerabilities in transitive package references of those used by the library_