### PR TITLE
Bug Fix: Inherited method fields not present in schema

### DIFF
--- a/src/graphql-aspnet/Constants.cs
+++ b/src/graphql-aspnet/Constants.cs
@@ -108,8 +108,12 @@ namespace GraphQL.AspNet
         /// <value>The known ignored field names.</value>
         public static ISet<string> IgnoredFieldNames { get; } = new HashSet<string>()
         {
+            // object declared methods that might be exposed
+            // also methods internally declared by structs that might be exposed
             "Deconstruct",
-            "ToString",
+            nameof(object.ToString),
+            nameof(object.GetHashCode),
+            nameof(object.GetType),
         };
 
         /// <summary>

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
@@ -46,11 +46,15 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             };
         }
 
-        /// <summary>
-        /// When overridden in a child class, this metyhod builds the route that will be assigned to this method
-        /// using the implementation rules of the concrete type.
-        /// </summary>
-        /// <returns>SchemaItemPath.</returns>
+        /// <inheritdoc />
+        protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
+        {
+            return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+              .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
+        }
+
+        /// <inheritdoc />
         protected override SchemaItemPath GenerateFieldPath()
         {
             var skipControllerLevelField = this.ObjectType.SingleAttributeOrDefault<GraphRootAttribute>();
@@ -77,11 +81,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             return new SchemaItemPath(template);
         }
 
-        /// <summary>
-        /// When overridden in a child class, allows the template to perform some final validation checks
-        /// on the integrity of itself. An exception should be thrown to stop the template from being
-        /// persisted if the object is unusable or otherwise invalid in the manner its been built.
-        /// </summary>
+        /// <inheritdoc />
         public override void ValidateOrThrow()
         {
             // cant use type naming on controllers (they arent real types and arent included directly in the object graph)
@@ -106,13 +106,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             base.ValidateOrThrow();
         }
 
-        /// <summary>
-        /// Determines whether the given container could be used as a graph field either because it is
-        /// explictly declared as such or that it conformed to the required parameters of being
-        /// a field.
-        /// </summary>
-        /// <param name="memberInfo">The member information to check.</param>
-        /// <returns><c>true</c> if the info represents a possible graph field; otherwise, <c>false</c>.</returns>
+        /// <inheritdoc />
         protected override bool CouldBeGraphField(MemberInfo memberInfo)
         {
             if (memberInfo == null || memberInfo is PropertyInfo)
@@ -125,12 +119,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             return memberInfo.SingleAttributeOfTypeOrDefault<GraphFieldAttribute>() != null;
         }
 
-        /// <summary>
-        /// When overridden in a child, allows the class to create custom template that inherit from <see cref="MethodGraphFieldTemplateBase" />
-        /// to provide additional functionality or garuntee a certian type structure for all methods on this object template.
-        /// </summary>
-        /// <param name="methodInfo">The method information.</param>
-        /// <returns>IGraphFieldTemplate.</returns>
+        /// <inheritdoc />
         protected override IGraphFieldTemplate CreateMethodFieldTemplate(MethodInfo methodInfo)
         {
             if (methodInfo == null)
@@ -142,12 +131,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 return new ControllerActionGraphFieldTemplate(this, methodInfo);
         }
 
-        /// <summary>
-        /// When overridden in a child, allows the class to create custom templates to provide additional functionality or
-        /// guarantee a certian type structure for all properties on this object template.
-        /// </summary>
-        /// <param name="prop">The property information.</param>
-        /// <returns>IGraphFieldTemplate.</returns>
+        /// <inheritdoc />
         protected override IGraphFieldTemplate CreatePropertyFieldTemplate(PropertyInfo prop)
         {
             // safety check to ensure properites on controllers can never be parsed as fields
@@ -174,10 +158,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         public IEnumerable<IGraphFieldTemplate> Extensions =>
             this.FieldTemplates.Values.OfType<GraphTypeExtensionFieldTemplate>();
 
-        /// <summary>
-        /// Gets the kind of graph type that can be made from this template.
-        /// </summary>
-        /// <value>The kind.</value>
+        /// <inheritdoc />
         public override TypeKind Kind => TypeKind.NONE;
     }
 }

--- a/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
@@ -118,8 +118,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             var parsedItems = new List<IInputGraphFieldTemplate>();
 
             var propMembers = this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(x => !x.IsSpecialName
-                    && x.GetSetMethod() != null && x.GetGetMethod() != null);
+                .Where(x => !x.IsSpecialName && x.GetSetMethod() != null && x.GetGetMethod() != null);
 
             foreach (var propInfo in propMembers)
             {

--- a/src/graphql-aspnet/Internal/TypeTemplates/InterfaceGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InterfaceGraphTypeTemplate.cs
@@ -10,7 +10,10 @@
 namespace GraphQL.AspNet.Internal.TypeTemplates
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
     using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Internal;
@@ -35,6 +38,14 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     $"The type '{interfaceType.FriendlyName()}' is not an interface and cannot be parsed as an interface graph type.",
                     interfaceType);
             }
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
+        {
+            return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+              .Where(x => !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
@@ -106,9 +106,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             // ------------------------------------
             var parsedItems = new List<IGraphFieldTemplate>();
 
-            var templateMembers = this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
-                .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
+            var templateMembers = this.GatherPossibleTemplateMembers();
 
             foreach (var member in templateMembers)
             {
@@ -157,6 +155,13 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 _interfaces.Add(iface);
             }
         }
+
+        /// <summary>
+        /// Extract the possible template members of <see cref="SchemaItemTemplateBase.ObjectType"/>
+        /// that might be includable in this template.
+        /// </summary>
+        /// <returns>IEnumerable&lt;MemberInfo&gt;.</returns>
+        protected abstract IEnumerable<MemberInfo> GatherPossibleTemplateMembers();
 
         /// <summary>
         /// Creates the member template from the given info. If overriden in a child class methods <see cref="CreatePropertyFieldTemplate"/> and

--- a/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
@@ -106,7 +106,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             // ------------------------------------
             var parsedItems = new List<IGraphFieldTemplate>();
 
-            var templateMembers = this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            var templateMembers = this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
                 .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
@@ -10,7 +10,10 @@
 namespace GraphQL.AspNet.Internal.TypeTemplates
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Schemas.TypeSystem;
 
@@ -27,6 +30,14 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         public ObjectGraphTypeTemplate(Type objectType)
             : base(objectType)
         {
+        }
+
+        /// <inheritdoc />
+        protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
+        {
+            return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+              .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         }
 
         /// <inheritdoc />

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/GraphTypeMakerTestBase.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/GraphTypeMakerTestBase.cs
@@ -20,7 +20,10 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
 
     public abstract class GraphTypeMakerTestBase
     {
-        protected GraphTypeCreationResult MakeGraphType(Type type, TypeKind kind, TemplateDeclarationRequirements? requirements = null)
+        protected GraphTypeCreationResult MakeGraphType(
+            Type type,
+            TypeKind kind,
+            TemplateDeclarationRequirements? requirements = null)
         {
             var builder = new TestServerBuilder(TestOptions.UseCodeDeclaredNames);
             if (requirements.HasValue)

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceThatInheritsDeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceThatInheritsDeclaredMethodField.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public interface InterfaceThatInheritsDeclaredMethodField : InterfaceWithDeclaredInterfaceField
+    {
+        string PropFieldOnInterface { get; set; }
+
+        int MethodFieldOnInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceThatInheritsUndeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceThatInheritsUndeclaredMethodField.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public interface InterfaceThatInheritsUndeclaredMethodField : InterfaceWithUndeclaredInterfaceField
+    {
+        string PropFieldOnInterface { get; set; }
+
+        int MethodFieldOnInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceWithDeclaredInterfaceField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceWithDeclaredInterfaceField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public interface InterfaceWithDeclaredInterfaceField
+    {
+        [GraphField]
+        string PropFieldOnBaseInterface { get; set; }
+
+        [GraphField]
+        int FieldOnBaseInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceWithUndeclaredInterfaceField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/InterfaceWithUndeclaredInterfaceField.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public interface InterfaceWithUndeclaredInterfaceField
+    {
+        string PropFieldOnBaseInterface { get; set; }
+
+        int MethodFieldOnBaseInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithDeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithDeclaredMethodField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithDeclaredMethodField
+    {
+        [GraphField]
+        public int FieldOnBaseObject(int item)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithInheritedDeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithInheritedDeclaredMethodField.cs
@@ -1,0 +1,16 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public class ObjectWithInheritedDeclaredMethodField : ObjectWithDeclaredMethodField
+    {
+        public int FieldOnClass { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithInheritedUndeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithInheritedUndeclaredMethodField.cs
@@ -1,0 +1,16 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public class ObjectWithInheritedUndeclaredMethodField : ObjectWithUndeclaredMethodField
+    {
+        public int FieldOnClass { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithUndeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithUndeclaredMethodField.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public class ObjectWithUndeclaredMethodField
+    {
+        public int FieldOnBaseObject(int item)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceGraphTypeTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceGraphTypeTemplateTests.cs
@@ -74,5 +74,36 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(INestedInterface1)));
             Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(INestedInterface2)));
         }
+
+        [Test]
+        public void Parse_InheritedUndeclaredMethodField_IsNotIncluded()
+        {
+            var template = new InterfaceGraphTypeTemplate(typeof(InterfaceThatInheritsUndeclaredMethodField));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            // PropFieldOnInterface, MethodFieldOnInterface
+            // base items are ignored
+            Assert.AreEqual(2, template.FieldTemplates.Count);
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.AreEqual(1, template.DeclaredInterfaces.Count());
+            Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(InterfaceWithUndeclaredInterfaceField)));
+        }
+
+        [Test]
+        public void Parse_InheritedDeclaredMethodField_IsNotIncluded()
+        {
+            var template = new InterfaceGraphTypeTemplate(typeof(InterfaceThatInheritsDeclaredMethodField));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count);
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsDeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsDeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+
+            Assert.AreEqual(1, template.DeclaredInterfaces.Count());
+            Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(InterfaceWithDeclaredInterfaceField)));
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceThatInheritsDeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceThatInheritsDeclaredMethodField.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.InterfaceTestData
+{
+    public interface InterfaceThatInheritsDeclaredMethodField : InterfaceWithDeclaredInterfaceField
+    {
+        string PropFieldOnInterface { get; set; }
+
+        int MethodFieldOnInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceThatInheritsUndeclaredMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceThatInheritsUndeclaredMethodField.cs
@@ -1,0 +1,20 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.InterfaceTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public interface InterfaceThatInheritsUndeclaredMethodField : InterfaceWithUndeclaredInterfaceField
+    {
+        string PropFieldOnInterface { get; set; }
+
+        int MethodFieldOnInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceWithDeclaredInterfaceField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceWithDeclaredInterfaceField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.InterfaceTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public interface InterfaceWithDeclaredInterfaceField
+    {
+        [GraphField]
+        string PropFieldOnBaseInterface { get; set; }
+
+        [GraphField]
+        int FieldOnBaseInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceWithUndeclaredInterfaceField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/InterfaceWithUndeclaredInterfaceField.cs
@@ -1,0 +1,18 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.InterfaceTestData
+{
+    public interface InterfaceWithUndeclaredInterfaceField
+    {
+        string PropFieldOnBaseInterface { get; set; }
+
+        int MethodFieldOnBaseInterface(int param1);
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
@@ -397,5 +397,29 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.AreEqual(1, template.FieldTemplates.Count);
             Assert.AreEqual(nameof(ObjectWithDeconstructor.Property1), template.FieldTemplates.First().Value.Name);
         }
+
+        [Test]
+        public void Parse_ExplicitInheritedMethodBasedField_IsSeenAsAGraphField()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(ObjectThatInheritsExplicitMethodField));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count);
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectThatInheritsExplicitMethodField.FieldOnObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectWithExplicitMethodField.FieldOnBaseObject)));
+        }
+
+        [Test]
+        public void Parse_NonExplicitMethodBasedField_IsSeenAsTemplatefield()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(ObjectThatInheritsNonExplicitMethodField));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count);
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectThatInheritsNonExplicitMethodField.FieldOnObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectWithNonExplicitMethodField.FieldOnBaseObject)));
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectThatInheritsExplicitMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectThatInheritsExplicitMethodField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectThatInheritsExplicitMethodField : ObjectWithExplicitMethodField
+    {
+        [GraphField]
+        public int FieldOnObject(int param2)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectThatInheritsNonExplicitMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectThatInheritsNonExplicitMethodField.cs
@@ -1,0 +1,21 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectThatInheritsNonExplicitMethodField : ObjectWithNonExplicitMethodField
+    {
+        public int FieldOnObject(int param2)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithExplicitMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithExplicitMethodField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithExplicitMethodField
+    {
+        [GraphField]
+        public int FieldOnBaseObject(int param1)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithNonExplicitMethodField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithNonExplicitMethodField.cs
@@ -1,0 +1,21 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithNonExplicitMethodField
+    {
+        public int FieldOnBaseObject(int param1)
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
 * Fixed a bug where method-based fields inherited from a parent class to a child class were not present on an `object` schema type representing the child class when they should have been.
 * Fixed a bug where method-based fields were fully ignored on an `interface` schema types in some circumstances even when they should have been included.

Fixes: #110 