### PR TITLE
Regression: Deserializing Subscription Start Requests

### DIFF
--- a/src/graphql-aspnet-subscriptions/Engine/DefaultGraphQLHttpSubscriptionMiddleware.cs
+++ b/src/graphql-aspnet-subscriptions/Engine/DefaultGraphQLHttpSubscriptionMiddleware.cs
@@ -169,8 +169,7 @@ namespace GraphQL.AspNet.Engine
                          clientConnection,
                          (int)ConnectionCloseStatus.ProtocolError,
                          (int)HttpStatusCode.BadRequest,
-                         $"The requested messaging protocol(s) '{uspe.Protocol}' are not supported " +
-                         "by the target schema.")
+                         $"The requested messaging protocol(s) '{uspe.Protocol}' are not supported.")
                  .ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -181,8 +180,7 @@ namespace GraphQL.AspNet.Engine
                         clientConnection,
                         (int)ConnectionCloseStatus.InternalServerError,
                         (int)HttpStatusCode.InternalServerError,
-                        "An unexpected error occured attempting to configure the web socket " +
-                        "connection. Check the server event logs for further details.")
+                        "An unexpected error occured attempting to configure the web socket.")
                 .ConfigureAwait(false);
             }
             finally

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
@@ -19,6 +19,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Execution;
+    using GraphQL.AspNet.Execution.Variables.Json;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Logging;
@@ -54,6 +55,9 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
             _deserializerOptions.PropertyNameCaseInsensitive = true;
             _deserializerOptions.AllowTrailingCommas = true;
             _deserializerOptions.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            _deserializerOptions.Converters.Add(new IInputVariableCollectionConverter());
+            _deserializerOptions.Converters.Add(new InputVariableCollectionConverter());
         }
 
         private readonly bool _enableMetrics;
@@ -99,9 +103,8 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
         /// <returns>Task.</returns>
         private async Task ResponseToUnknownMessageAsync(GqltwsMessage lastMessage)
         {
-            var error = "The last message recieved was unknown or could not be processed " +
-                        $"by this server. This connection is configured to use the {GqltwsConstants.PROTOCOL_NAME} " +
-                        $"message schema. (messageType: '{lastMessage.Type}')";
+            var error = $"The last message recieved could not be processed (Protocol: {GqltwsConstants.PROTOCOL_NAME}) " +
+                        $"(MessageType: '{lastMessage.Type}').";
 
             await this.CloseConnectionAsync(
                 (ConnectionCloseStatus)GqltwsConstants.CustomCloseEventIds.InvalidMessageType,

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
@@ -18,6 +18,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
     using System.Threading;
     using System.Threading.Tasks;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Execution.Variables.Json;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Interfaces.Execution;
     using GraphQL.AspNet.Interfaces.Logging;
@@ -52,6 +53,9 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
             _deserializeOptions.PropertyNameCaseInsensitive = true;
             _deserializeOptions.AllowTrailingCommas = true;
             _deserializeOptions.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            _deserializeOptions.Converters.Add(new IInputVariableCollectionConverter());
+            _deserializeOptions.Converters.Add(new InputVariableCollectionConverter());
         }
 
         private readonly bool _enableMetrics;


### PR DESCRIPTION
* Fixed a regression in deserializing subscription start requests due to a change in the json conversion routines with the file upload changes
* Shortened several `connection-closed` messages that were too long for the allotted space.