### PR TITLE
Bug Fix: Multipart processor type checks

### DIFF
--- a/src/graphql-aspnet/ServerExtensions/MultipartRequests/MultipartRequestServerExtension.cs
+++ b/src/graphql-aspnet/ServerExtensions/MultipartRequests/MultipartRequestServerExtension.cs
@@ -66,8 +66,6 @@ namespace GraphQL.AspNet.ServerExtensions.MultipartRequests
             var configType = typeof(MultipartRequestConfiguration<>).MakeGenericType(_schemaType);
             _config = InstanceFactory.CreateInstance(configType) as MultipartRequestConfiguration;
 
-            _expectedProcessorType = typeof(MultipartRequestGraphQLHttpProcessor<>).MakeGenericType(_schemaType);
-
             if (_config == null)
             {
                 throw new SchemaConfigurationException(
@@ -77,6 +75,8 @@ namespace GraphQL.AspNet.ServerExtensions.MultipartRequests
 
             if (_configAction != null)
                 _configAction(_config);
+
+            _expectedProcessorType = typeof(MultipartRequestGraphQLHttpProcessor<>).MakeGenericType(_schemaType);
 
             if (_config.RegisterMultipartRequestHttpProcessor)
             {

--- a/src/graphql-aspnet/ServerExtensions/MultipartRequests/MultipartRequestServerExtension.cs
+++ b/src/graphql-aspnet/ServerExtensions/MultipartRequests/MultipartRequestServerExtension.cs
@@ -66,6 +66,8 @@ namespace GraphQL.AspNet.ServerExtensions.MultipartRequests
             var configType = typeof(MultipartRequestConfiguration<>).MakeGenericType(_schemaType);
             _config = InstanceFactory.CreateInstance(configType) as MultipartRequestConfiguration;
 
+            _expectedProcessorType = typeof(MultipartRequestGraphQLHttpProcessor<>).MakeGenericType(_schemaType);
+
             if (_config == null)
             {
                 throw new SchemaConfigurationException(
@@ -88,7 +90,6 @@ namespace GraphQL.AspNet.ServerExtensions.MultipartRequests
                         $"cannot be registered for the '{_schemaType.FriendlyName()}' schema.");
                 }
 
-                _expectedProcessorType = typeof(MultipartRequestGraphQLHttpProcessor<>).MakeGenericType(_schemaType);
                 options.QueryHandler.HttpProcessorType = _expectedProcessorType;
             }
 

--- a/src/unit-tests/graphql-aspnet-tests/ServerExtensions/MutlipartRequests/MultiPartRequestServerExtensionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/ServerExtensions/MutlipartRequests/MultiPartRequestServerExtensionTests.cs
@@ -10,16 +10,21 @@
 namespace GraphQL.AspNet.Tests.ServerExtensions.MutlipartRequests
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Configuration.Exceptions;
     using GraphQL.AspNet.Engine;
+    using GraphQL.AspNet.Interfaces.Web;
     using GraphQL.AspNet.Schemas;
     using GraphQL.AspNet.ServerExtensions.MultipartRequests;
     using GraphQL.AspNet.ServerExtensions.MultipartRequests.Engine;
     using GraphQL.AspNet.ServerExtensions.MultipartRequests.Model;
     using GraphQL.AspNet.ServerExtensions.MultipartRequests.Schema;
+    using GraphQL.AspNet.Tests.Execution.TestData.DirectiveProcessorTypeSystemLocationTestData;
     using GraphQL.AspNet.Tests.Framework;
+    using GraphQL.AspNet.Tests.ServerExtensions.MutlipartRequests.TestData;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
     using NUnit.Framework;
 
     [TestFixture]
@@ -134,7 +139,103 @@ namespace GraphQL.AspNet.Tests.ServerExtensions.MutlipartRequests
             options.RegisterExtension(extension);
 
             // no provider passed
-            extension.UseExtension();
+            var provider = collection.BuildServiceProvider();
+            var scopedProvider = provider.CreateScope();
+
+            extension.UseExtension(serviceProvider: scopedProvider.ServiceProvider);
+        }
+
+        [Test]
+        public void UseExtension_CheckingForACompatiableProvider_NoConfigChanges_ProviderFirst_ThrowsException()
+        {
+            using var restorePoint = new GraphQLGlobalRestorePoint(true);
+
+            var extension = new MultipartRequestServerExtension((o) => { });
+            var serverBuilder = new TestServerBuilder();
+
+            serverBuilder.TryAddSingleton<IGraphQLHttpProcessor<GraphSchema>, CompatiableMultipartProcessor<GraphSchema>>();
+            serverBuilder.AddGraphQL(options =>
+                {
+                    // compatiable provider placed before extension invoked
+                    options.QueryHandler.HttpProcessorType = typeof(CompatiableMultipartProcessor<GraphSchema>);
+
+                    options.RegisterExtension(extension);
+                });
+
+            Assert.Throws<SchemaConfigurationException>(() =>
+            {
+                var server = serverBuilder.Build();
+            });
+        }
+
+        [Test]
+        public void UseExtension_CheckingForACompatiableProvider_NoConfigChanges_ProviderLast_IsValid()
+        {
+            using var restorePoint = new GraphQLGlobalRestorePoint(true);
+
+            var extension = new MultipartRequestServerExtension((o) => { });
+            var serverBuilder = new TestServerBuilder();
+
+            serverBuilder.TryAddSingleton<IGraphQLHttpProcessor<GraphSchema>, CompatiableMultipartProcessor<GraphSchema>>();
+            serverBuilder.AddGraphQL(options =>
+            {
+                options.RegisterExtension(extension);
+
+                // compatiable provider placed after extension invoked
+                options.QueryHandler.HttpProcessorType = typeof(CompatiableMultipartProcessor<GraphSchema>);
+            });
+
+            var server = serverBuilder.Build();
+        }
+
+        [Test]
+        public void UseExtension_NotRegisteringProvider_CheckingForACompatiableProvider_ProviderLast_IsValid()
+        {
+            using var restorePoint = new GraphQLGlobalRestorePoint(true);
+
+            var extension = new MultipartRequestServerExtension((o) =>
+            {
+                o.RegisterMultipartRequestHttpProcessor = false;
+                o.RequireMultipartRequestHttpProcessor = true;
+            });
+
+            var serverBuilder = new TestServerBuilder();
+
+            serverBuilder.TryAddSingleton<IGraphQLHttpProcessor<GraphSchema>, CompatiableMultipartProcessor<GraphSchema>>();
+            serverBuilder.AddGraphQL(options =>
+            {
+                options.RegisterExtension(extension);
+
+                // compatiable provider placed after extension invoked
+                options.QueryHandler.HttpProcessorType = typeof(CompatiableMultipartProcessor<GraphSchema>);
+            });
+
+            var server = serverBuilder.Build();
+        }
+
+        [Test]
+        public void UseExtension_NotRegisteringProvider_CheckingForACompatiableProvider_ProviderFirst_IsValid()
+        {
+            using var restorePoint = new GraphQLGlobalRestorePoint(true);
+
+            var extension = new MultipartRequestServerExtension((o) =>
+            {
+                o.RegisterMultipartRequestHttpProcessor = false;
+                o.RequireMultipartRequestHttpProcessor = true;
+            });
+
+            var serverBuilder = new TestServerBuilder();
+
+            serverBuilder.TryAddSingleton<IGraphQLHttpProcessor<GraphSchema>, CompatiableMultipartProcessor<GraphSchema>>();
+            serverBuilder.AddGraphQL(options =>
+            {
+                // compatiable provider placed after extension invoked
+                options.QueryHandler.HttpProcessorType = typeof(CompatiableMultipartProcessor<GraphSchema>);
+
+                options.RegisterExtension(extension);
+            });
+
+            var server = serverBuilder.Build();
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/ServerExtensions/MutlipartRequests/TestData/CompatiableMultipartProcessor.cs
+++ b/src/unit-tests/graphql-aspnet-tests/ServerExtensions/MutlipartRequests/TestData/CompatiableMultipartProcessor.cs
@@ -1,0 +1,31 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.ServerExtensions.MutlipartRequests.TestData
+{
+    using GraphQL.AspNet.Interfaces.Engine;
+    using GraphQL.AspNet.Interfaces.Logging;
+    using GraphQL.AspNet.Interfaces.Schema;
+    using GraphQL.AspNet.ServerExtensions.MultipartRequests.Engine;
+    using GraphQL.AspNet.ServerExtensions.MultipartRequests.Interfaces;
+
+    public class CompatiableMultipartProcessor<TSchema> : MultipartRequestGraphQLHttpProcessor<TSchema>
+        where TSchema : class, ISchema
+    {
+        public CompatiableMultipartProcessor(
+            TSchema schema,
+            IGraphQLRuntime<TSchema> runtime,
+            IQueryResponseWriter<TSchema> writer,
+            IMultiPartHttpFormPayloadParser<TSchema> parser,
+            IGraphEventLogger logger = null)
+            : base(schema, runtime, writer, parser, logger)
+        {
+        }
+    }
+}


### PR DESCRIPTION
* The multipart form extension should no longer throw an exception when registering a custom http processor of the correct type before adding the extension to the schema when instructing the extension to not register its own built in processor.