### PR TITLE
Bug: Controller Inherited Action Invocations

### DIFF
--- a/src/graphql-aspnet/Controllers/GraphControllerBase.cs
+++ b/src/graphql-aspnet/Controllers/GraphControllerBase.cs
@@ -74,7 +74,9 @@ namespace GraphQL.AspNet.Controllers
 
                 _schemaItemContext.Logger?.ActionMethodModelStateValidated(_action, this.Request, this.ModelState);
 
-                if (_action.Method.DeclaringType != this.GetType())
+                // ensure this controller type is or inherits from the controller type where the method is actually
+                // declared as the method will be invoked aganst this instance.
+                if (!Validation.IsCastable(this.GetType(), _action.Method.DeclaringType))
                 {
                     throw new TargetException($"Unable to invoke action '{_action.Route.Path}' on controller '{this.GetType().FriendlyName()}'. The controller " +
                                               "does not own the method.");
@@ -97,7 +99,7 @@ namespace GraphQL.AspNet.Controllers
                     }
                     else
                     {
-                        // given all the checking and parsing this should be imnpossible, but just in case
+                        // given all the checking and parsing this should be impossible, but just in case
                         invokeReturn = new InternalServerErrorGraphActionResult(
                             $"The action '{_action.Route.Path}' is defined " +
                             $"as asyncronous but it did not return a {typeof(Task)}.");

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/AppleController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/AppleController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    [GraphRoute("apples")]
+    public class AppleController : FruitController
+    {
+        [Query]
+        public int TotalApples()
+        {
+            return 85;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/EmployeeController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/EmployeeController.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    [GraphRoute("employees")]
+    public class EmployeeController : PersonController
+    {
+        [Query]
+        public int TotalEmployees()
+        {
+            return 5;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/FruitController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/FruitController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    [GraphRoute("fruit")]
+    public class FruitController : GraphController
+    {
+        [Query]
+        public int TotalFruit()
+        {
+            return 32;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/HouseController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/HouseController.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    [GraphRoute("houseFloorPlan")]
+    public class HouseController : RoomController
+    {
+        [Query]
+        public int TotalFloors()
+        {
+            return 2;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/PersonController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/PersonController.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class PersonController : GraphController
+    {
+        [Query]
+        public int TotalPeople()
+        {
+            return 99;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/RoomController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/RoomController.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    [GraphRoute("roomsAvailable")]
+    public class RoomController : GraphController
+    {
+        [Query]
+        public int TotalRooms()
+        {
+            return 5;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTemplateTests.cs
@@ -111,5 +111,18 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.AreEqual(typeof(DirectiveWithArgs), appliedDirective.DirectiveType);
             Assert.AreEqual(new object[] { 101, "controller arg" }, appliedDirective.Arguments);
         }
+
+        [Test]
+        public void Parse_InheritedAction_IsIncludedInTheTemplate()
+        {
+            var template = new GraphControllerTemplate(typeof(ControllerWithInheritedAction));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.Actions.Count());
+
+            Assert.IsNotNull(template.Actions.Single(x => x.Name.EndsWith(nameof(BaseControllerWithAction.BaseControllerAction))));
+            Assert.IsNotNull(template.Actions.Single(x => x.Name.EndsWith(nameof(ControllerWithInheritedAction.ChildControllerAction))));
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/BaseControllerWithAction.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/BaseControllerWithAction.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class BaseControllerWithAction : GraphController
+    {
+        [Query]
+        public int BaseControllerAction()
+        {
+            return 0;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ControllerWithInheritedAction.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ControllerWithInheritedAction.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ControllerWithInheritedAction : BaseControllerWithAction
+    {
+        [Query]
+        public int ChildControllerAction()
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
* Fixed a bug where by actions defined on a base controller were correctly added to the schema but could not be properly invoked by a controller that inherited from said base controller.
* Added unit tests for various scenarios involving abstract and non-abstract base classes


Fixes #121 