### PR TITLE
Validation Improvements

### DIFF
--- a/build/strict-linting.ruleset
+++ b/build/strict-linting.ruleset
@@ -123,6 +123,7 @@
     <Rule Id="SA1410" Action="Error" />
     <Rule Id="SA1411" Action="Error" />
     <Rule Id="SA1412" Action="Error" />
+	<Rule Id="SA1500" Action="Error" />
     <Rule Id="SA1503" Action="None" />
 	<Rule Id="SA1507" Action="Error" />
     <Rule Id="SA1512" Action="Error" />

--- a/src/graphql-aspnet-subscriptions/Internal/TypeTemplates/SubscriptionControllerActionGraphFieldTemplate.cs
+++ b/src/graphql-aspnet-subscriptions/Internal/TypeTemplates/SubscriptionControllerActionGraphFieldTemplate.cs
@@ -76,7 +76,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc/>
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
             // ensure the custom event name is valid if it was supplied
             if (string.IsNullOrWhiteSpace(this.EventName))
@@ -114,7 +114,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                         $"{typeof(SubscriptionSourceAttribute).FriendlyName()} to explicitly assign a source data parameter.");
             }
 
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
         }
 
         /// <inheritdoc/>

--- a/src/graphql-aspnet/Configuration/Startup/SchemaPreCacher.cs
+++ b/src/graphql-aspnet/Configuration/Startup/SchemaPreCacher.cs
@@ -66,7 +66,7 @@ namespace GraphQL.AspNet.Configuration.Startup
 
             if (template is IGraphTypeFieldTemplateContainer fieldContainer)
             {
-                foreach (var dependent in fieldContainer.FieldTemplates.Values.SelectMany(x => x.RetrieveRequiredTypes()))
+                foreach (var dependent in fieldContainer.FieldTemplates.SelectMany(x => x.RetrieveRequiredTypes()))
                 {
                     this.PreParseTypeAndChildren(dependent.Type);
                 }

--- a/src/graphql-aspnet/Engine/DefaultTypeTemplateProvider.cs
+++ b/src/graphql-aspnet/Engine/DefaultTypeTemplateProvider.cs
@@ -78,7 +78,6 @@ namespace GraphQL.AspNet.Engine
 
             template = this.MakeTemplate(objectType, typeKind);
             template.Parse();
-            template.ValidateOrThrow();
 
             if (this.CacheTemplates)
                 _knownObjects.TryAdd(typeKey, template);

--- a/src/graphql-aspnet/Engine/TypeMakers/DirectiveMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/DirectiveMaker.cs
@@ -42,10 +42,14 @@ namespace GraphQL.AspNet.Engine.TypeMakers
         /// <returns>GraphTypeCreationResult.</returns>
         public GraphTypeCreationResult CreateGraphType(Type concreteType)
         {
+            Validation.ThrowIfNull(concreteType, nameof(concreteType));
+
             var formatter = _schema.Configuration.DeclarationOptions.GraphNamingFormatter;
             var template = GraphQLProviders.TemplateProvider.ParseType(concreteType) as IGraphDirectiveTemplate;
             if (template == null)
                 return null;
+
+            template.ValidateOrThrow(false);
 
             var securityGroups = new List<AppliedSecurityPolicyGroup>();
 

--- a/src/graphql-aspnet/Engine/TypeMakers/EnumGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/EnumGraphTypeMaker.cs
@@ -38,9 +38,13 @@ namespace GraphQL.AspNet.Engine.TypeMakers
         /// <inheritdoc />
         public GraphTypeCreationResult CreateGraphType(Type concreteType)
         {
+            Validation.ThrowIfNull(concreteType, nameof(concreteType));
+
             var template = GraphQLProviders.TemplateProvider.ParseType(concreteType, TypeKind.ENUM) as IEnumGraphTypeTemplate;
             if (template == null)
                 return null;
+
+            template.ValidateOrThrow(false);
 
             var requirements = template.DeclarationRequirements ?? _schema.Configuration.DeclarationOptions.FieldDeclarationRequirements;
 
@@ -70,6 +74,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             var enumValuesToInclude = template.Values.Where(value => requirements.AllowImplicitEnumValues() || value.IsExplicitDeclaration);
             foreach (var value in enumValuesToInclude)
             {
+                value.ValidateOrThrow(false);
+
                 // enum option directives
                 var valueDirectives = value.CreateAppliedDirectives();
 

--- a/src/graphql-aspnet/Engine/TypeMakers/GraphArgumentMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/GraphArgumentMaker.cs
@@ -35,6 +35,10 @@ namespace GraphQL.AspNet.Engine.TypeMakers
         public GraphArgumentCreationResult CreateArgument(ISchemaItem owner, IGraphArgumentTemplate template)
         {
             Validation.ThrowIfNull(owner, nameof(owner));
+            Validation.ThrowIfNull(template, nameof(template));
+
+            template.ValidateOrThrow(false);
+
             var formatter = _schema.Configuration.DeclarationOptions.GraphNamingFormatter;
 
             var directives = template.CreateAppliedDirectives();

--- a/src/graphql-aspnet/Engine/TypeMakers/GraphFieldMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/GraphFieldMaker.cs
@@ -39,6 +39,10 @@ namespace GraphQL.AspNet.Engine.TypeMakers
         /// <inheritdoc />
         public virtual GraphFieldCreationResult<IGraphField> CreateField(IGraphFieldTemplate template)
         {
+            Validation.ThrowIfNull(template, nameof(template));
+
+            template.ValidateOrThrow(false);
+
             var formatter = this.Schema.Configuration.DeclarationOptions.GraphNamingFormatter;
             var result = new GraphFieldCreationResult<IGraphField>();
 

--- a/src/graphql-aspnet/Engine/TypeMakers/InputObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/InputObjectGraphTypeMaker.cs
@@ -12,7 +12,9 @@ namespace GraphQL.AspNet.Engine.TypeMakers
     using System;
     using System.Linq;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Configuration;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Interfaces.Schema;
@@ -76,6 +78,15 @@ namespace GraphQL.AspNet.Engine.TypeMakers
                 inputObjectType.AddField(fieldResult.Field);
 
                 result.MergeDependents(fieldResult);
+            }
+
+            // at least one field should have been rendered
+            if (inputObjectType.Fields.Count == 0)
+            {
+                throw new GraphTypeDeclarationException(
+                  $"The input object graph type '{template.ObjectType.FriendlyName()}' defines 0 fields. " +
+                  $"All input object types must define at least one field.",
+                  template.ObjectType);
             }
 
             result.GraphType = inputObjectType;

--- a/src/graphql-aspnet/Engine/TypeMakers/InputObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/InputObjectGraphTypeMaker.cs
@@ -41,6 +41,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             if (template == null)
                 return null;
 
+            template.ValidateOrThrow(false);
+
             var formatter = _schema.Configuration.DeclarationOptions.GraphNamingFormatter;
             var result = new GraphTypeCreationResult();
 

--- a/src/graphql-aspnet/Engine/TypeMakers/InterfaceGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/InterfaceGraphTypeMaker.cs
@@ -11,6 +11,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
 {
     using System;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Extensions;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Interfaces.Schema;
@@ -70,6 +72,16 @@ namespace GraphQL.AspNet.Engine.TypeMakers
                 interfaceType.Extend(fieldResult.Field);
 
                 result.MergeDependents(fieldResult);
+            }
+
+            // at least one field should have been rendered
+            // the type is invalid if there are no fields othe than __typename
+            if (interfaceType.Fields.Count == 1)
+            {
+                throw new GraphTypeDeclarationException(
+                  $"The interface graph type '{template.ObjectType.FriendlyName()}' defines 0 fields. " +
+                  $"All interface types must define at least one field.",
+                  template.ObjectType);
             }
 
             // add in declared interfaces by name

--- a/src/graphql-aspnet/Engine/TypeMakers/InterfaceGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/InterfaceGraphTypeMaker.cs
@@ -43,6 +43,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             if (template == null)
                 return null;
 
+            template.ValidateOrThrow(false);
+
             var result = new GraphTypeCreationResult();
             var formatter = _schema.Configuration.DeclarationOptions.GraphNamingFormatter;
 

--- a/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
@@ -52,6 +52,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             if (template == null)
                 return null;
 
+            template.ValidateOrThrow(false);
+
             var result = new GraphTypeCreationResult();
 
             var formatter = _schema.Configuration.DeclarationOptions.GraphNamingFormatter;

--- a/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
@@ -76,7 +76,8 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             result.AddDependentRange(template.RetrieveRequiredTypes());
 
             var fieldMaker = GraphQLProviders.GraphTypeMakerProvider.CreateFieldMaker(_schema);
-            foreach (var fieldTemplate in ObjectGraphTypeMaker.GatherFieldTemplates(template, _schema))
+            var templatesToRender = ObjectGraphTypeMaker.GatherFieldTemplates(template, _schema);
+            foreach (var fieldTemplate in templatesToRender)
             {
                 var fieldResult = fieldMaker.CreateField(fieldTemplate);
                 objectType.Extend(fieldResult.Field);

--- a/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
@@ -116,7 +116,7 @@ namespace GraphQL.AspNet.Engine.TypeMakers
             // gather the fields to include in the graph type
             var requiredDeclarations = template.DeclarationRequirements ?? schema.Configuration.DeclarationOptions.FieldDeclarationRequirements;
 
-            return template.FieldTemplates.Values.Where(x =>
+            return template.FieldTemplates.Where(x =>
             {
                 if (x.IsExplicitDeclaration)
                     return true;

--- a/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
+++ b/src/graphql-aspnet/Engine/TypeMakers/ObjectGraphTypeMaker.cs
@@ -13,7 +13,9 @@ namespace GraphQL.AspNet.Engine.TypeMakers
     using System.Collections.Generic;
     using System.Linq;
     using GraphQL.AspNet.Common;
+    using GraphQL.AspNet.Common.Extensions;
     using GraphQL.AspNet.Configuration;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Engine;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Interfaces.Schema;
@@ -82,6 +84,16 @@ namespace GraphQL.AspNet.Engine.TypeMakers
                 var fieldResult = fieldMaker.CreateField(fieldTemplate);
                 objectType.Extend(fieldResult.Field);
                 result.MergeDependents(fieldResult);
+            }
+
+            // at least one field should have been rendered
+            // the type is invalid if there are no fields othe than __typename
+            if (objectType.Fields.Count == 1)
+            {
+                throw new GraphTypeDeclarationException(
+                  $"The object graph type '{template.ObjectType.FriendlyName()}' defines 0 fields. " +
+                  $"All object types must define at least one field.",
+                  template.ObjectType);
             }
 
             // add in declared interfaces by name

--- a/src/graphql-aspnet/Interfaces/Internal/IGraphTypeFieldTemplateContainer.cs
+++ b/src/graphql-aspnet/Interfaces/Internal/IGraphTypeFieldTemplateContainer.cs
@@ -20,6 +20,6 @@ namespace GraphQL.AspNet.Interfaces.Internal
         /// Gets the explicitly and implicitly decalred fields found on this instance.
         /// </summary>
         /// <value>The fields declared on this template.</value>
-        IReadOnlyDictionary<string, IGraphFieldTemplate> FieldTemplates { get; }
+        IReadOnlyList<IGraphFieldTemplate> FieldTemplates { get; }
     }
 }

--- a/src/graphql-aspnet/Interfaces/Internal/ISchemaItemTemplate.cs
+++ b/src/graphql-aspnet/Interfaces/Internal/ISchemaItemTemplate.cs
@@ -34,7 +34,9 @@ namespace GraphQL.AspNet.Interfaces.Internal
         /// on the integrity of itself. An exception should be thrown to stop the template from being
         /// persisted if the object is unusable or otherwise invalid in the manner its been built.
         /// </summary>
-        void ValidateOrThrow();
+        /// <param name="validateChildren">if set to <c>true</c> any child items (e.g. fields on an interface, arguments on a field)
+        /// are also validated.</param>
+        void ValidateOrThrow(bool validateChildren = true);
 
         /// <summary>
         /// Parses the template contents according to the rules of the template.

--- a/src/graphql-aspnet/Internal/GraphValidation.cs
+++ b/src/graphql-aspnet/Internal/GraphValidation.cs
@@ -343,13 +343,13 @@ namespace GraphQL.AspNet.Internal
             }
 
             // Func<T>, Action<T>, any declared "delegate"
-            if (Validation.IsCastable<MulticastDelegate>(type))
+            if (Validation.IsCastable<Delegate>(type))
             {
                 if (throwOnFailure)
                 {
                     throw new GraphTypeDeclarationException(
-                        $"The type '{type.FriendlyName()}' appears to be a {nameof(MulticastDelegate)} (e.g. Func<T>, Action<T>). " +
-                        "Multicast delegates cannot be used as schema items under any circumstances.",
+                        $"The type '{type.FriendlyName()}' appears to be a {nameof(Delegate)} (e.g. Func<T>, Action<T>). " +
+                        "Delegates cannot be used as schema items under any circumstances.",
                         type);
                 }
 

--- a/src/graphql-aspnet/Internal/GraphValidation.cs
+++ b/src/graphql-aspnet/Internal/GraphValidation.cs
@@ -342,6 +342,20 @@ namespace GraphQL.AspNet.Internal
                 }
             }
 
+            // Func<T>, Action<T>, any declared "delegate"
+            if (Validation.IsCastable<MulticastDelegate>(type))
+            {
+                if (throwOnFailure)
+                {
+                    throw new GraphTypeDeclarationException(
+                        $"The type '{type.FriendlyName()}' appears to be a {nameof(MulticastDelegate)} (e.g. Func<T>, Action<T>). " +
+                        "Multicast delegates cannot be used as schema items under any circumstances.",
+                        type);
+                }
+
+                return false;
+            }
+
             return true;
         }
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/ControllerActionGraphFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ControllerActionGraphFieldTemplate.cs
@@ -59,14 +59,10 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             return new SchemaItemPath(SchemaItemPath.Join(fieldType, parentRouteFragment, routeFragment));
         }
 
-        /// <summary>
-        /// When overridden in a child class, allows the template to perform some final validation checks
-        /// on the integrity of itself. An exception should be thrown to stop the template from being
-        /// persisted if the object is unusable or otherwise invalid in the manner its been built.
-        /// </summary>
-        public override void ValidateOrThrow()
+        /// <inheritdoc />
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             // as a matter of convention enforcement
             // for action methods on controllers

--- a/src/graphql-aspnet/Internal/TypeTemplates/EnumGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/EnumGraphTypeTemplate.cs
@@ -144,8 +144,6 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 foreach (var option in this.Values)
                     option.ValidateOrThrow(validateChildren);
             }
-
-            _valuesTolabels = null;
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/EnumGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/EnumGraphTypeTemplate.cs
@@ -107,14 +107,10 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             }
         }
 
-        /// <summary>
-        /// When overridden in a child class, allows the template to perform some final validation checks
-        /// on the integrity of itself. An exception should be thrown to stop the template from being
-        /// persisted if the object is unusable or otherwise invalid in the manner its been built.
-        /// </summary>
-        public override void ValidateOrThrow()
+        /// <inheritdoc />
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (!this.ObjectType.IsEnum)
             {
@@ -143,8 +139,11 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 throw new GraphTypeDeclarationException(msg, this.ObjectType);
             }
 
-            foreach (var option in this.Values)
-                option.ValidateOrThrow();
+            if (validateChildren)
+            {
+                foreach (var option in this.Values)
+                    option.ValidateOrThrow(validateChildren);
+            }
 
             _valuesTolabels = null;
         }

--- a/src/graphql-aspnet/Internal/TypeTemplates/EnumValueTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/EnumValueTemplate.cs
@@ -60,7 +60,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
             GraphValidation.EnsureGraphNameOrThrow($"{this.InternalFullName}", this.Name);
         }

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphArgumentTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphArgumentTemplate.cs
@@ -225,11 +225,22 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     $".NET parameter. (Declared '{this.TypeExpression}' is incompatiable with '{actualTypeExpression}') ");
             }
 
-            if (!this.ArgumentModifiers.IsInternalParameter() && this.ObjectType.IsInterface)
+            if (!this.ArgumentModifiers.IsInternalParameter())
             {
-                throw new GraphTypeDeclarationException(
-                    $"The item '{this.Parent.InternalFullName}' declares an argument '{this.Name}' of type  '{this.ObjectType.FriendlyName()}' " +
-                    $"which is an interface. Interfaces cannot be used as input arguments to any type.");
+                if (this.ObjectType.IsInterface)
+                {
+                    // special error message for trying to use an interface in an argument
+                    throw new GraphTypeDeclarationException(
+                        $"The item '{this.Parent.InternalFullName}' declares an argument '{this.Name}' of type  '{this.ObjectType.FriendlyName()}' " +
+                        $"which is an interface. Interfaces cannot be used as input arguments to any type.");
+                }
+
+                if (!GraphValidation.IsValidGraphType(this.ObjectType))
+                {
+                    throw new GraphTypeDeclarationException(
+                        $"The item '{this.Parent.InternalFullName}' declares an argument '{this.Name}' of type  '{this.ObjectType.FriendlyName()}' " +
+                        $"which is not a valid graph type.");
+                }
             }
 
             foreach (var directive in this.AppliedDirectives)

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphArgumentTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphArgumentTemplate.cs
@@ -199,7 +199,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public void ValidateOrThrow()
+        public void ValidateOrThrow(bool validateChildren = true)
         {
             GraphValidation.EnsureGraphNameOrThrow(this.InternalFullName, this.Name);
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
@@ -82,7 +82,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
             // cant use type naming on controllers (they arent real types and arent included directly in the object graph)
             if (this.AttributeProvider.SingleAttributeOfTypeOrDefault<GraphTypeAttribute>() != null)
@@ -103,7 +103,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     "one or the other.");
             }
 
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
@@ -50,7 +50,13 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
         {
             return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-              .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Where(x =>
+                    !x.IsAbstract &&
+                    !x.IsGenericMethod &&
+                    !x.IsSpecialName &&
+                    x.DeclaringType != typeof(object) &&
+                    x.DeclaringType != typeof(ValueType))
+              .Cast<MemberInfo>()
               .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         }
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
@@ -149,7 +149,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         /// </summary>
         /// <value>The fields.</value>
         public IEnumerable<IGraphFieldTemplate> Actions =>
-            this.FieldTemplates.Values.OfType<ControllerActionGraphFieldTemplate>();
+            this.FieldTemplates.OfType<ControllerActionGraphFieldTemplate>();
 
         /// <summary>
         /// Gets operation types to which this object can declare a field.
@@ -162,7 +162,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         /// </summary>
         /// <value>The extensions.</value>
         public IEnumerable<IGraphFieldTemplate> Extensions =>
-            this.FieldTemplates.Values.OfType<GraphTypeExtensionFieldTemplate>();
+            this.FieldTemplates.OfType<GraphTypeExtensionFieldTemplate>();
 
         /// <inheritdoc />
         public override TypeKind Kind => TypeKind.CONTROLLER;

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphControllerTemplate.cs
@@ -165,6 +165,6 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             this.FieldTemplates.Values.OfType<GraphTypeExtensionFieldTemplate>();
 
         /// <inheritdoc />
-        public override TypeKind Kind => TypeKind.NONE;
+        public override TypeKind Kind => TypeKind.CONTROLLER;
     }
 }

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveMethodTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveMethodTemplate.cs
@@ -122,12 +122,8 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             return builder.ToString();
         }
 
-        /// <summary>
-        /// When overridden in a child class, allows the template to perform some final validation checks
-        /// on the integrity of itself. An exception should be thrown to stop the template from being
-        /// persisted if the object is unusable or otherwise invalid in the manner its been built.
-        /// </summary>
-        public virtual void ValidateOrThrow()
+        /// <inheritdoc />
+        public virtual void ValidateOrThrow(bool validateChildren = true)
         {
             // ensure skip isnt set
             if (this.Method.SingleAttributeOrDefault<GraphSkipAttribute>() != null)
@@ -167,8 +163,11 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     $"All directive methods must return a {nameof(IGraphActionResult)} or {typeof(Task<IGraphActionResult>).FriendlyName()}");
             }
 
-            foreach (var argument in _arguments)
-                argument.ValidateOrThrow();
+            if (validateChildren)
+            {
+                foreach (var argument in _arguments)
+                    argument.ValidateOrThrow(validateChildren);
+            }
 
             foreach (var directive in this.AppliedDirectives)
                 directive.ValidateOrThrow();

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveMethodTemplateContainer.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveMethodTemplateContainer.cs
@@ -121,7 +121,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         /// on the integrity of itself. An exception should be thrown to stop the template from being
         /// persisted if the object is unusable or otherwise invalid in the manner its been built.
         /// </summary>
-        public void ValidateOrThrow()
+        /// <param name="validateChildren">if set to <c>true</c> any child items (e.g. fields on an interface, arguments on a field)
+        /// are also validated.</param>
+        public void ValidateOrThrow(bool validateChildren = true)
         {
             if (_duplicateDirectiveLocations != null && _duplicateDirectiveLocations.Count > 0)
             {
@@ -144,7 +146,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             GraphDirectiveMethodTemplate baseExecutionMethod = null;
             foreach (var kvp in _templateMap)
             {
-                kvp.Value.ValidateOrThrow();
+                kvp.Value.ValidateOrThrow(validateChildren);
 
                 if (baseExecutionMethod == null)
                 {

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphDirectiveTemplate.cs
@@ -90,9 +90,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (this.Locations == DirectiveLocation.NONE)
             {
@@ -108,7 +108,8 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     $"Directives cannot have applied directives.");
             }
 
-            this.Methods.ValidateOrThrow();
+            if (validateChildren)
+                this.Methods.ValidateOrThrow(validateChildren);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
@@ -179,9 +179,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (_invalidTypeExpression)
             {
@@ -300,9 +300,12 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 }
             }
 
-            // general validation of any declaraed parameter for this field
-            foreach (var argument in this.Arguments)
-                argument.ValidateOrThrow();
+            if (validateChildren)
+            {
+                // general validation of any declaraed parameter for this field
+                foreach (var argument in this.Arguments)
+                    argument.ValidateOrThrow(validateChildren);
+            }
 
             if (this.Complexity.HasValue && this.Complexity < 0)
             {

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
@@ -220,6 +220,16 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                         "or remove the union.");
                 }
             }
+            else
+            {
+                // when not a union proxy the return type of the field matters and must be valid
+                if (!GraphValidation.IsValidGraphType(this.ObjectType))
+                {
+                    throw new GraphTypeDeclarationException(
+                        $"The field  '{this.InternalFullName}' defines a a return type of {this.ObjectType.FriendlyName()}, which is cannot a be used as a graph type. " +
+                        $"Change the return type or skip the field and try again.");
+                }
+            }
 
             // ensure the object type returned by the graph field is set correctly
             bool returnsActionResult = Validation.IsCastable<IGraphActionResult>(this.ObjectType);

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphTypeExtensionFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphTypeExtensionFieldTemplate.cs
@@ -80,7 +80,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
             if (_typeAttrib == null)
             {
@@ -97,7 +97,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     "Leaf types cannot be extended.");
             }
 
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/InputGraphFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InputGraphFieldTemplate.cs
@@ -87,9 +87,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (Validation.IsCastable<Task>(this.DeclaredReturnType))
             {

--- a/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
@@ -173,9 +173,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (_duplicateNames != null && _duplicateNames.Any())
             {
@@ -197,8 +197,11 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                     this.ObjectType);
             }
 
-            foreach (var field in this.FieldTemplates.Values)
-                field.ValidateOrThrow();
+            if (validateChildren)
+            {
+                foreach (var field in this.FieldTemplates.Values)
+                    field.ValidateOrThrow(validateChildren);
+            }
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/InterfaceGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InterfaceGraphTypeTemplate.cs
@@ -44,7 +44,12 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
         {
             return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-              .Where(x => !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Where(x =>
+                        !x.IsGenericMethod &&
+                        !x.IsSpecialName &&
+                        x.DeclaringType != typeof(object) &&
+                        x.DeclaringType != typeof(ValueType))
+              .Cast<MemberInfo>()
               .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         }
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplate.cs
@@ -48,9 +48,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             // as a matter of convention enforcement
             // for methods delcared as fields on POCOs (not controller actions)

--- a/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplateBase.cs
@@ -73,9 +73,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             if (this.Method.IsStatic)
             {

--- a/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/NonLeafGraphTypeTemplateBase.cs
@@ -263,7 +263,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
                 var fieldNames = string.Join("\n", _invalidFields.Select(x => $"Field: '{x.InternalFullName} ({x.Route.RootCollection.ToString()})'"));
                 throw new GraphTypeDeclarationException(
                     $"Invalid field declarations.  The type '{this.InternalFullName}' declares fields belonging to a graph collection not allowed given its context. This type can " +
-                    $"only declare the following graph collections: '{string.Join(", ", this.AllowedSchemaItemCollections.Select(x => x.ToString()))}'. " +
+                    $"only be declared the following graph collections: '{string.Join(", ", this.AllowedSchemaItemCollections.Select(x => x.ToString()))}'. " +
                     $"If this field is declared on an object (not a controller) be sure to use '{nameof(GraphFieldAttribute)}' instead " +
                     $"of '{nameof(QueryAttribute)}' or '{nameof(MutationAttribute)}'.\n---------\n " + fieldNames,
                     this.ObjectType);

--- a/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
@@ -36,7 +36,13 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         protected override IEnumerable<MemberInfo> GatherPossibleTemplateMembers()
         {
             return this.ObjectType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-              .Where(x => !x.IsAbstract && !x.IsGenericMethod && !x.IsSpecialName).Cast<MemberInfo>()
+              .Where(x =>
+                        !x.IsAbstract &&
+                        !x.IsGenericMethod &&
+                        !x.IsSpecialName &&
+                        x.DeclaringType != typeof(object) &&
+                        x.DeclaringType != typeof(ValueType))
+              .Cast<MemberInfo>()
               .Concat(this.ObjectType.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         }
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/ObjectGraphTypeTemplate.cs
@@ -14,6 +14,8 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
     using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
+    using GraphQL.AspNet.Common.Extensions;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Schemas.TypeSystem;
 

--- a/src/graphql-aspnet/Internal/TypeTemplates/PropertyGraphFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/PropertyGraphFieldTemplate.cs
@@ -59,9 +59,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public override void ValidateOrThrow()
+        public override void ValidateOrThrow(bool validateChildren = true)
         {
-            base.ValidateOrThrow();
+            base.ValidateOrThrow(validateChildren);
 
             // ensure property has a public getter (kinda useless otherwise)
             if (this.Property.GetGetMethod() == null)

--- a/src/graphql-aspnet/Internal/TypeTemplates/SchemaItemTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/SchemaItemTemplateBase.cs
@@ -82,7 +82,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
-        public virtual void ValidateOrThrow()
+        public virtual void ValidateOrThrow(bool validateChildren = true)
         {
             if (!_isParsed)
             {

--- a/src/graphql-aspnet/Schemas/Structural/GraphFieldCollection.cs
+++ b/src/graphql-aspnet/Schemas/Structural/GraphFieldCollection.cs
@@ -50,12 +50,17 @@ namespace GraphQL.AspNet.Schemas.Structural
 
             if (_fields.ContainsKey(field.Name))
             {
+                Type ownerType = null;
+                if (_owner is ITypedSchemaItem tsi)
+                    ownerType = tsi.ObjectType;
+
                 throw new GraphTypeDeclarationException(
                     $"Duplicate field name detected. The graph type '{_owner.Name}' already declares a field named '{field.Name}'. " +
                     "This may occur if a type extension is added with the same name as an existing field, " +
                     "when an attempt is made to extend an OBJECT type through a direct field extension and an indirect " +
                     "interface field extension with the same name or when a schema attempts to include multiple overloads " +
-                    "of the same method on a class, interface or struct.");
+                    "of the same method on a class, interface or struct.",
+                    ownerType);
             }
 
             field.AssignParent(_owner);

--- a/src/graphql-aspnet/Schemas/Structural/GraphFieldCollection.cs
+++ b/src/graphql-aspnet/Schemas/Structural/GraphFieldCollection.cs
@@ -51,10 +51,11 @@ namespace GraphQL.AspNet.Schemas.Structural
             if (_fields.ContainsKey(field.Name))
             {
                 throw new GraphTypeDeclarationException(
-                    $"Duplciate field name detected. The graph type '{_owner.Name}' already declares a field named '{field.Name}'. " +
-                    "This may occur if a type extension is added with the same name as an existing field or " +
-                    "when an attempt is made to extend an OBJECT type through a direct extension and an indirect " +
-                    "INTERFACE extension with the same field name.");
+                    $"Duplicate field name detected. The graph type '{_owner.Name}' already declares a field named '{field.Name}'. " +
+                    "This may occur if a type extension is added with the same name as an existing field, " +
+                    "when an attempt is made to extend an OBJECT type through a direct field extension and an indirect " +
+                    "interface field extension with the same name or when a schema attempts to include multiple overloads " +
+                    "of the same method on a class, interface or struct.");
             }
 
             field.AssignParent(_owner);

--- a/src/graphql-aspnet/Schemas/Structural/InputGraphFieldCollection.cs
+++ b/src/graphql-aspnet/Schemas/Structural/InputGraphFieldCollection.cs
@@ -52,7 +52,7 @@ namespace GraphQL.AspNet.Schemas.Structural
             if (_fields.ContainsKey(field.Name))
             {
                 throw new GraphTypeDeclarationException(
-                    $"Duplciate field name detected. The input object type '{_owner.Name}' already " +
+                    $"Duplicate field name detected. The input object type '{_owner.Name}' already " +
                     $"declares a field named '{field.Name}'.");
             }
 

--- a/src/graphql-aspnet/Schemas/Structural/VirtualResolvedObject.cs
+++ b/src/graphql-aspnet/Schemas/Structural/VirtualResolvedObject.cs
@@ -22,9 +22,7 @@ namespace GraphQL.AspNet.Schemas.Structural
     /// non-concrete nature of virtual graph fields and the need for all resolvers to return usable data for downstream resolvers.
     /// </summary>
     [DebuggerDisplay("Virtual Object (GraphTypeName = {GraphTypeName})")]
-    [GraphType(
-        Publish = false,
-        FieldDeclarationRequirements = TemplateDeclarationRequirements.RequireMethodAndProperties)]
+    [GraphType(Publish = false)]
     public sealed class VirtualResolvedObject
     {
         /// <summary>

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/Internal/Templating/GraphControllerTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/Internal/Templating/GraphControllerTemplateTests.cs
@@ -29,7 +29,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
 
             Assert.AreEqual(1, template.FieldTemplates.Count());
             Assert.AreEqual(1, template.Actions.Count());
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[subscription]/SimpleSubscription/WidgetWatcher"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[subscription]/SimpleSubscription/WidgetWatcher"));
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-testframework/GraphQLSchemaHelperMethods.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/GraphQLSchemaHelperMethods.cs
@@ -9,6 +9,7 @@
 
 namespace GraphQL.AspNet.Tests.Framework
 {
+    using System;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Configuration.Formatting;
     using GraphQL.AspNet.Interfaces.Schema;

--- a/src/unit-tests/graphql-aspnet-testframework/GraphQLTemplateHelper.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/GraphQLTemplateHelper.cs
@@ -49,7 +49,7 @@ namespace GraphQL.AspNet.Tests.Framework
             var template = new SingleMethodGraphControllerTemplate<TController>(methodName);
             template.Parse();
             template.ValidateOrThrow();
-            return template.FieldTemplates.FirstOrDefault(x => x.Value.InternalName.Equals(methodName, StringComparison.OrdinalIgnoreCase)).Value;
+            return template.FieldTemplates.FirstOrDefault(x => x.InternalName.Equals(methodName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -68,11 +68,11 @@ namespace GraphQL.AspNet.Tests.Framework
             // can occur when setting up a test do to references occuring out of process
             foreach (var kvp in template.FieldTemplates)
             {
-                if (string.Equals(kvp.Value.InternalName, fieldOrMethodName, StringComparison.OrdinalIgnoreCase))
-                    return kvp.Value;
+                if (string.Equals(kvp.InternalName, fieldOrMethodName, StringComparison.OrdinalIgnoreCase))
+                    return kvp;
 
-                if (string.Equals(kvp.Value.Route.Name, fieldOrMethodName, StringComparison.OrdinalIgnoreCase))
-                    return kvp.Value;
+                if (string.Equals(kvp.Route.Name, fieldOrMethodName, StringComparison.OrdinalIgnoreCase))
+                    return kvp;
             }
 
             throw new ArgumentOutOfRangeException(nameof(fieldOrMethodName), $"Test Setup Error. No field,method or property named '{fieldOrMethodName}' was found on the template of type '{typeof(TType).FriendlyName()}'.");

--- a/src/unit-tests/graphql-aspnet-testframework/TestServer.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/TestServer.cs
@@ -375,8 +375,7 @@ namespace GraphQL.AspNet.Tests.Framework
             }
 
             var fieldTemplate = fieldContainer.FieldTemplates
-                .SingleOrDefault(x => string.Compare(x.Value.Name, fieldName, StringComparison.OrdinalIgnoreCase) == 0)
-                .Value;
+                .SingleOrDefault(x => string.Compare(x.Name, fieldName, StringComparison.OrdinalIgnoreCase) == 0);
 
             if (fieldTemplate == null)
             {

--- a/src/unit-tests/graphql-aspnet-tests/CommonHelpers/SimpleObject.cs
+++ b/src/unit-tests/graphql-aspnet-tests/CommonHelpers/SimpleObject.cs
@@ -1,0 +1,19 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.CommonHelpers
+{
+    /// <summary>
+    /// A representation of a data object with 1 property.
+    /// </summary>
+    public class SimpleObject
+    {
+        public int Value { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam1.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam1.cs
@@ -19,5 +19,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam1.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam1.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ObjectWithInvalidMethodParam1
+    {
+        // no param func
+        public int InvalidTestMethod(Func<TwoPropertyObject> param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam2.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ObjectWithInvalidMethodParam2
+    {
+        public int InvalidTestMethod(Action<TwoPropertyObject, bool> param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam2.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam2.cs
@@ -18,5 +18,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam3.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam3.cs
@@ -19,5 +19,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam3.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam3.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ObjectWithInvalidMethodParam3
+    {
+        // no return action
+        public int InvalidTestMethod(Action param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam4.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam4.cs
@@ -1,0 +1,23 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public class ObjectWithInvalidMethodParam4
+    {
+        // this method doesnt' represent a valid signature for any schema
+        public int InvalidTestMethod(Func<TwoPropertyObject, bool> param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam4.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam4.cs
@@ -19,5 +19,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam5.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam5.cs
@@ -1,0 +1,25 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+
+    public delegate void MyDelegate(int param1);
+
+    public class ObjectWithInvalidMethodParam5
+    {
+        // a custom delegate
+        public int InvalidTestMethod(MyDelegate param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam5.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam5.cs
@@ -21,5 +21,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam6.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam6.cs
@@ -1,0 +1,24 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Framework.Interfaces;
+
+    public class ObjectWithInvalidMethodParam6
+    {
+        // interfaces aren't allowed
+        public int InvalidTestMethod(ISinglePropertyObject param1)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam6.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidMethodParam6.cs
@@ -20,5 +20,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
         {
             return 1;
         }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidPropertyType.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidPropertyType.cs
@@ -1,0 +1,21 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
+{
+    using System;
+    using GraphQL.AspNet.Tests.Framework.CommonHelpers;
+    using GraphQL.AspNet.Tests.Framework.Interfaces;
+
+    public class ObjectWithInvalidPropertyType
+    {
+        // interfaces aren't allowed
+        public Func<int> InvalidProperty { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidPropertyType.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTestData/ObjectWithInvalidPropertyType.cs
@@ -17,5 +17,7 @@ namespace GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData
     {
         // interfaces aren't allowed
         public Func<int> InvalidProperty { get; set; }
+
+        public int Prop1 { get; set; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/SchemaInjectorTests.cs
@@ -1,0 +1,49 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Configuration
+{
+    using System;
+    using System.Threading.Tasks;
+    using GraphQL.AspNet.Configuration.Startup;
+    using GraphQL.AspNet.Schemas;
+    using GraphQL.AspNet.Tests.Configuration.SchemaInjectorTestData;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SchemaInjectorTests
+    {
+        [TestCase(typeof(ObjectWithInvalidMethodParam1))]
+        [TestCase(typeof(ObjectWithInvalidMethodParam2))]
+        [TestCase(typeof(ObjectWithInvalidMethodParam3))]
+        [TestCase(typeof(ObjectWithInvalidMethodParam4))]
+        [TestCase(typeof(ObjectWithInvalidMethodParam5))]
+        [TestCase(typeof(ObjectWithInvalidMethodParam6))]
+        [TestCase(typeof(ObjectWithInvalidPropertyType))]
+        public void UseGraphQL_WithObjectWithInvalidMethod_DoesNotFail(Type objectType)
+        {
+            var collection = new ServiceCollection();
+
+            var injector = GraphQLSchemaInjectorFactory.Create<GraphSchema>(
+                collection,
+                o =>
+                {
+                    o.AddType(objectType);
+                });
+
+            injector.ConfigureServices();
+
+            var provider = collection.BuildServiceProvider();
+
+            // no exception should be thrown
+            injector.UseSchema(provider);
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/FieldMaker_StandardFieldTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/FieldMaker_StandardFieldTests.cs
@@ -99,7 +99,7 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
 
             Assert.AreEqual(1, template.FieldTemplates.Count);
 
-            var field = template.FieldTemplates.FirstOrDefault().Value;
+            var field = template.FieldTemplates.FirstOrDefault();
             Assert.AreEqual(nameof(NullableEnumController.ConvertUnit), field.Name);
             Assert.AreEqual(typeof(int), field.ObjectType);
 

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InputObjectGraphTypeMakerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InputObjectGraphTypeMakerTests.cs
@@ -10,6 +10,7 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
 {
     using System.Linq;
     using GraphQL.AspNet.Configuration;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Schema;
     using GraphQL.AspNet.Internal;
     using GraphQL.AspNet.Internal.TypeTemplates;
@@ -206,6 +207,18 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
             Assert.IsNotNull(appliedDirective);
             Assert.AreEqual(typeof(DirectiveWithArgs), appliedDirective.DirectiveType);
             CollectionAssert.AreEqual(new object[] { 44, "input arg" }, appliedDirective.ArgumentValues);
+        }
+
+        [Test]
+        public void InputObject_CreateGraphType_WithNoFields_ThrowsError()
+        {
+            var ex = Assert.Throws<GraphTypeDeclarationException>(() =>
+            {
+                var result = this.MakeGraphType(
+                    typeof(ObjectWithNoFields),
+                    TypeKind.INPUT_OBJECT,
+                    TemplateDeclarationRequirements.None);
+            });
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InputObjectGraphTypeMakerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InputObjectGraphTypeMakerTests.cs
@@ -195,8 +195,7 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
         [Test]
         public void InputObject_CreateGraphType_DirectivesAreApplied()
         {
-            // config says properties DO require declaration, override on type says it does not
-            var result = this.MakeGraphType(typeof(InputTypeWithDirective), TypeKind.INPUT_OBJECT, TemplateDeclarationRequirements.Property);
+            var result = this.MakeGraphType(typeof(InputTypeWithDirective), TypeKind.INPUT_OBJECT);
             var inputType = result.GraphType as IInputObjectGraphType;
 
             Assert.IsNotNull(inputType);

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InterfaceTypeMakerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/InterfaceTypeMakerTests.cs
@@ -11,6 +11,7 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
     using System.Linq;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Engine;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Schema;
     using GraphQL.AspNet.Schemas.TypeSystem;
     using GraphQL.AspNet.Tests.Engine.TypeMakers.TestData;
@@ -130,6 +131,18 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsDeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsDeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, Constants.ReservedNames.TYPENAME_FIELD)));
+        }
+
+        [Test]
+        public void CreateGraphType_WithNoFields_ThrowsError()
+        {
+            var ex = Assert.Throws<GraphTypeDeclarationException>(() =>
+            {
+                var result = this.MakeGraphType(
+                    typeof(IInterfaceWithNoFields),
+                    TypeKind.INTERFACE,
+                    TemplateDeclarationRequirements.None);
+            });
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/ObjectGraphTypeMakerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/ObjectGraphTypeMakerTests.cs
@@ -11,6 +11,7 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
     using System.Linq;
     using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Engine;
+    using GraphQL.AspNet.Execution.Exceptions;
     using GraphQL.AspNet.Interfaces.Internal;
     using GraphQL.AspNet.Interfaces.Schema;
     using GraphQL.AspNet.Schemas;
@@ -278,6 +279,37 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, nameof(ObjectWithInheritedDeclaredMethodField.FieldOnClass), System.StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, nameof(ObjectWithUndeclaredMethodField.FieldOnBaseObject), System.StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, Constants.ReservedNames.TYPENAME_FIELD)));
+        }
+
+        [Test]
+        public void CreateGraphType_AsObject_WhenOverloadedMethodIncludesOnce_IsCorrectlyCreated()
+        {
+            var result = this.MakeGraphType(
+                typeof(ObjectWithOverloadedMethodFields),
+                TypeKind.OBJECT,
+                TemplateDeclarationRequirements.Default);
+
+            var objectType = result.GraphType as IObjectGraphType;
+
+            // inherited and declared method field should not be counted
+            Assert.IsNotNull(objectType);
+
+            // declared field method + __typename
+            Assert.AreEqual(2, objectType.Fields.Count);
+            Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, nameof(ObjectWithOverloadedMethodFields.Field1), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(objectType.Fields.Any(x => string.Equals(x.Name, Constants.ReservedNames.TYPENAME_FIELD)));
+        }
+
+        [Test]
+        public void CreateGraphType_AsObject_WhenOverloadedMethodIncludesTwice_ThrowsError()
+        {
+            var ex = Assert.Throws<GraphTypeDeclarationException>(() =>
+            {
+                var result = this.MakeGraphType(
+                    typeof(ObjectWithOverloadedMethodFields),
+                    TypeKind.OBJECT,
+                    TemplateDeclarationRequirements.None);
+            });
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/ObjectGraphTypeMakerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/ObjectGraphTypeMakerTests.cs
@@ -311,5 +311,17 @@ namespace GraphQL.AspNet.Tests.Engine.TypeMakers
                     TemplateDeclarationRequirements.None);
             });
         }
+
+        [Test]
+        public void CreateGraphType_AsObject_WithNoFields_ThrowsError()
+        {
+            var ex = Assert.Throws<GraphTypeDeclarationException>(() =>
+            {
+                var result = this.MakeGraphType(
+                    typeof(ObjectWithNoFields),
+                    TypeKind.OBJECT,
+                    TemplateDeclarationRequirements.None);
+            });
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/IInterfaceWithNoFields.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/IInterfaceWithNoFields.cs
@@ -1,0 +1,15 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public interface IInterfaceWithNoFields
+    {
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithNoFields.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithNoFields.cs
@@ -1,0 +1,15 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    public class ObjectWithNoFields
+    {
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithOverloadedMethodFields.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/ObjectWithOverloadedMethodFields.cs
@@ -7,14 +7,21 @@
 // License:  MIT
 // *************************************************************
 
-namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
 {
     using GraphQL.AspNet.Attributes;
-    using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.Internal.Templating.DirectiveTestData;
 
-    [ApplyDirective(typeof(DirectiveWithArgs), 101, "controller arg")]
-    public class ControllerWithDirective : GraphController
+    public class ObjectWithOverloadedMethodFields
     {
+        [GraphField]
+        public int Field1(int arg1)
+        {
+            return 0;
+        }
+
+        public int Field1(string arg2)
+        {
+            return 0;
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/IntrospectionTests.cs
@@ -331,9 +331,9 @@ namespace GraphQL.AspNet.Tests.Execution
             Assert.IsNotNull(spected.Fields);
             Assert.AreEqual(3, spected.Fields.Count);
 
-            var expected0 = template.FieldTemplates[$"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Method1)}"];
-            var expected1 = template.FieldTemplates[$"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Method2)}"];
-            var expected2 = template.FieldTemplates[$"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Prop1)}"];
+            var expected0 = template.FieldTemplates.First(x => x.Route.Path == $"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Method1)}");
+            var expected1 = template.FieldTemplates.First(x => x.Route.Path == $"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Method2)}");
+            var expected2 = template.FieldTemplates.First(x => x.Route.Path == $"[type]/{nameof(IntrospectableObject)}/{nameof(IntrospectableObject.Prop1)}");
 
             var field0 = spected.Fields.FirstOrDefault(x => x.Name == nameof(IntrospectableObject.Method1));
             var field1 = spected.Fields.FirstOrDefault(x => x.Name == nameof(IntrospectableObject.Method2));

--- a/src/unit-tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -23,6 +23,7 @@ namespace GraphQL.AspNet.Tests.Internal
     public class GraphValidationTests
     {
         public delegate int MyTestDelegate(int arg1);
+
         public enum ValidationTestEnum
         {
             Value1,

--- a/src/unit-tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/GraphValidationTests.cs
@@ -22,6 +22,7 @@ namespace GraphQL.AspNet.Tests.Internal
     [TestFixture]
     public class GraphValidationTests
     {
+        public delegate int MyTestDelegate(int arg1);
         public enum ValidationTestEnum
         {
             Value1,
@@ -85,6 +86,11 @@ namespace GraphQL.AspNet.Tests.Internal
         [TestCase(typeof(IDictionary<string, int>), false)]
         [TestCase(typeof(IReadOnlyDictionary<string, int>), false)]
         [TestCase(typeof(object), false)]
+        [TestCase(typeof(Func<int, bool>), false)]
+        [TestCase(typeof(Func<int>), false)]
+        [TestCase(typeof(Action<int, bool>), false)]
+        [TestCase(typeof(Action), false)]
+        [TestCase(typeof(MyTestDelegate), false)]
         public void IsValidGraphType(Type inputType, bool isValidType)
         {
             var result = GraphValidation.IsValidGraphType(inputType);

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTemplateTests.cs
@@ -56,9 +56,9 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.AreEqual(3, template.FieldTemplates.Count());
             Assert.AreEqual(2, template.Actions.Count());
             Assert.AreEqual(1, template.Extensions.Count());
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[mutation]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[query]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/TwoPropertyObject/Property3"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[mutation]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[query]/TwoMethodsDifferentRoots/{nameof(TwoMethodsDifferentRootsController.ActionMethodNoAttributes)}"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[type]/TwoPropertyObject/Property3"));
         }
 
         [Test]

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ControllerWithDirective.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ControllerTestData/ControllerWithDirective.cs
@@ -16,5 +16,6 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
     [ApplyDirective(typeof(DirectiveWithArgs), 101, "controller arg")]
     public class ControllerWithDirective : GraphController
     {
+
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/DirectiveMethodTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/DirectiveMethodTemplateTests.cs
@@ -40,19 +40,17 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.AreEqual(mock, template.Parent);
             Assert.AreEqual(method, template.Method);
 
-            Assert.AreEqual("IGraphActionResult (object source, int arg1, string arg2)", template.MethodSignature);
+            Assert.AreEqual("IGraphActionResult (int arg1, string arg2)", template.MethodSignature);
             Assert.AreEqual(nameof(SimpleExecutableDirective.Execute), template.Name);
             Assert.AreEqual($"Simple.{nameof(SimpleExecutableDirective.Execute)}", template.InternalFullName);
             Assert.IsTrue(template.IsAsyncField);
             Assert.AreEqual(typeof(IGraphActionResult), template.ObjectType);
             Assert.AreEqual(DirectiveLocation.FIELD, template.Locations);
-            Assert.AreEqual(3, template.Arguments.Count);
-            Assert.AreEqual("source", template.Arguments[0].Name);
-            Assert.AreEqual(typeof(object), template.Arguments[0].ObjectType);
-            Assert.AreEqual("arg1", template.Arguments[1].Name);
-            Assert.AreEqual(typeof(int), template.Arguments[1].ObjectType);
-            Assert.AreEqual("arg2", template.Arguments[2].Name);
-            Assert.AreEqual(typeof(string), template.Arguments[2].ObjectType);
+            Assert.AreEqual(2, template.Arguments.Count);
+            Assert.AreEqual("arg1", template.Arguments[0].Name);
+            Assert.AreEqual(typeof(int), template.Arguments[0].ObjectType);
+            Assert.AreEqual("arg2", template.Arguments[1].Name);
+            Assert.AreEqual(typeof(string), template.Arguments[1].ObjectType);
             Assert.IsTrue(template.IsExplicitDeclaration);
             Assert.AreEqual(GraphFieldSource.Method, template.FieldSource);
 

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/DirectiveTestData/SimpleExecutableDirective.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/DirectiveTestData/SimpleExecutableDirective.cs
@@ -20,7 +20,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating.DirectiveTestData
     public class SimpleExecutableDirective : GraphDirective
     {
         [DirectiveLocations(DirectiveLocation.FIELD)]
-        public Task<IGraphActionResult> Execute(object source, int arg1, string arg2)
+        public Task<IGraphActionResult> Execute(int arg1, string arg2)
         {
             return Task.FromResult(null as IGraphActionResult);
         }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceGraphTypeTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceGraphTypeTemplateTests.cs
@@ -85,8 +85,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             // PropFieldOnInterface, MethodFieldOnInterface
             // base items are ignored
             Assert.AreEqual(2, template.FieldTemplates.Count);
-            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsUndeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
             Assert.AreEqual(1, template.DeclaredInterfaces.Count());
             Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(InterfaceWithUndeclaredInterfaceField)));
         }
@@ -99,11 +99,22 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             template.ValidateOrThrow();
 
             Assert.AreEqual(2, template.FieldTemplates.Count);
-            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsDeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Value.Name, nameof(InterfaceThatInheritsDeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsDeclaredMethodField.PropFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => string.Equals(x.Name, nameof(InterfaceThatInheritsDeclaredMethodField.MethodFieldOnInterface), System.StringComparison.OrdinalIgnoreCase)));
 
             Assert.AreEqual(1, template.DeclaredInterfaces.Count());
             Assert.IsTrue(template.DeclaredInterfaces.Contains(typeof(InterfaceWithDeclaredInterfaceField)));
+        }
+
+        [Test]
+        public void Parse_InterfaceWithMethodOverloads_ShouldParseBothAndNotFail()
+        {
+            var template = new InterfaceGraphTypeTemplate(typeof(IInterfaceWithOverloads));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count);
+            Assert.IsTrue(template.FieldTemplates.All(x => x.Name == nameof(IInterfaceWithOverloads.Method1)));
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/IInterfaceWithOverloads.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/InterfaceTestData/IInterfaceWithOverloads.cs
@@ -7,14 +7,15 @@
 // License:  MIT
 // *************************************************************
 
-namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+namespace GraphQL.AspNet.Tests.Internal.Templating.InterfaceTestData
 {
     using GraphQL.AspNet.Attributes;
-    using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.Internal.Templating.DirectiveTestData;
 
-    [ApplyDirective(typeof(DirectiveWithArgs), 101, "controller arg")]
-    public class ControllerWithDirective : GraphController
+    public interface IInterfaceWithOverloads
     {
+        int Method1(int i);
+
+        [GraphField]
+        int Method1();
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
@@ -102,8 +102,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).Count(x => !x.IsSpecialName);
 
             Assert.IsTrue(totalMethods == template.FieldTemplates.Count);
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.Value.IsExplicitDeclaration));
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.Value.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.IsExplicitDeclaration));
         }
 
         [Test]
@@ -117,8 +117,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).Count(x => !x.IsSpecialName);
 
             Assert.IsTrue(totalMethods == template.FieldTemplates.Count);
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.Value.IsExplicitDeclaration));
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.Value.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.IsExplicitDeclaration));
         }
 
         [Test]
@@ -131,8 +131,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             var totalProps = typeof(OneMarkedProperty).GetProperties().Length;
 
             Assert.IsTrue(totalProps == template.FieldTemplates.Count);
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.Value.IsExplicitDeclaration));
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.Value.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.IsExplicitDeclaration));
         }
 
         public void Parse_Struct_PropertiesAreCapturedAsExplictOrImplicitCorrectly()
@@ -144,8 +144,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             var totalProps = typeof(StructOneMarkedProperty).GetProperties().Length;
 
             Assert.IsTrue(totalProps == template.FieldTemplates.Count);
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.Value.IsExplicitDeclaration));
-            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.Value.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => x.IsExplicitDeclaration));
+            Assert.AreEqual(1, template.FieldTemplates.Count(x => !x.IsExplicitDeclaration));
         }
 
         [Test]
@@ -158,8 +158,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsNotNull(template);
 
             Assert.AreEqual(2, template.FieldTemplates.Count());
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/{nameof(TwoMethodsWithSameNameWithAttributeDiff)}/{nameof(TwoMethodsWithSameNameWithAttributeDiff.Method1)}"));
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/{nameof(TwoMethodsWithSameNameWithAttributeDiff)}/MethodA"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[type]/{nameof(TwoMethodsWithSameNameWithAttributeDiff)}/{nameof(TwoMethodsWithSameNameWithAttributeDiff.Method1)}"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[type]/{nameof(TwoMethodsWithSameNameWithAttributeDiff)}/MethodA"));
         }
 
         [Test]
@@ -172,32 +172,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsNotNull(template);
 
             Assert.AreEqual(2, template.FieldTemplates.Count());
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/{nameof(StructTwoMethodsWithSameNameWithAttributeDiff)}/{nameof(TwoMethodsWithSameNameWithAttributeDiff.Method1)}"));
-            Assert.IsTrue(template.FieldTemplates.ContainsKey($"[type]/{nameof(StructTwoMethodsWithSameNameWithAttributeDiff)}/MethodA"));
-        }
-
-        [Test]
-        public void Parse_Object_OverloadedMethodsWithNameClash_ThrowsException()
-        {
-            var template = new ObjectGraphTypeTemplate(typeof(TwoMethodsWithSameName));
-            template.Parse();
-
-            Assert.Throws<GraphTypeDeclarationException>(() =>
-            {
-                template.ValidateOrThrow();
-            });
-        }
-
-        [Test]
-        public void Parse_Struct_OverloadedMethodsWithNameClash_ThrowsException()
-        {
-            var template = new ObjectGraphTypeTemplate(typeof(StructTwoMethodsWithSameName));
-            template.Parse();
-
-            Assert.Throws<GraphTypeDeclarationException>(() =>
-            {
-                template.ValidateOrThrow();
-            });
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[type]/{nameof(StructTwoMethodsWithSameNameWithAttributeDiff)}/{nameof(TwoMethodsWithSameNameWithAttributeDiff.Method1)}"));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.Route.Path == $"[type]/{nameof(StructTwoMethodsWithSameNameWithAttributeDiff)}/MethodA"));
         }
 
         [Test]
@@ -300,7 +276,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
                 MetaGraphTypes.IsList);
 
             Assert.AreEqual(1, template.FieldTemplates.Count());
-            var fieldTemplate = template.FieldTemplates.ElementAt(0).Value;
+            var fieldTemplate = template.FieldTemplates.ElementAt(0);
             Assert.AreEqual(typeof(TwoPropertyObject[]), fieldTemplate.DeclaredReturnType);
             Assert.AreEqual(typeof(TwoPropertyObject), fieldTemplate.ObjectType);
             Assert.AreEqual(expectedTypeExpression, fieldTemplate.TypeExpression);
@@ -315,8 +291,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
 
             // Key, Value
             Assert.AreEqual(2, template.FieldTemplates.Count());
-            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
-            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0);
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1);
 
             Assert.AreEqual(typeof(string), fieldTemplate0.DeclaredReturnType);
             Assert.AreEqual(typeof(string), fieldTemplate0.ObjectType);
@@ -334,9 +310,9 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             template.ValidateOrThrow();
 
             Assert.AreEqual(3, template.FieldTemplates.Count());
-            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
-            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
-            var fieldTemplate2 = template.FieldTemplates.ElementAt(2).Value;
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0);
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1);
+            var fieldTemplate2 = template.FieldTemplates.ElementAt(2);
 
             Assert.AreEqual("Property3", fieldTemplate0.Name);
             Assert.AreEqual("Property1", fieldTemplate1.Name);
@@ -395,7 +371,7 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             template.ValidateOrThrow();
 
             Assert.AreEqual(1, template.FieldTemplates.Count);
-            Assert.AreEqual(nameof(ObjectWithDeconstructor.Property1), template.FieldTemplates.First().Value.Name);
+            Assert.AreEqual(nameof(ObjectWithDeconstructor.Property1), template.FieldTemplates.First().Name);
         }
 
         [Test]
@@ -406,8 +382,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             template.ValidateOrThrow();
 
             Assert.AreEqual(2, template.FieldTemplates.Count);
-            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectThatInheritsExplicitMethodField.FieldOnObject)));
-            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectWithExplicitMethodField.FieldOnBaseObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.InternalName == nameof(ObjectThatInheritsExplicitMethodField.FieldOnObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.InternalName == nameof(ObjectWithExplicitMethodField.FieldOnBaseObject)));
         }
 
         [Test]
@@ -418,8 +394,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             template.ValidateOrThrow();
 
             Assert.AreEqual(2, template.FieldTemplates.Count);
-            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectThatInheritsNonExplicitMethodField.FieldOnObject)));
-            Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectWithNonExplicitMethodField.FieldOnBaseObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.InternalName == nameof(ObjectThatInheritsNonExplicitMethodField.FieldOnObject)));
+            Assert.IsTrue(template.FieldTemplates.Any(x => x.InternalName == nameof(ObjectWithNonExplicitMethodField.FieldOnBaseObject)));
         }
 
         [Test]
@@ -431,8 +407,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
 
             Assert.AreEqual(2, template.FieldTemplates.Count());
 
-            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
-            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0);
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1);
 
             // the only public property and method (regardless of field inclusions)
             Assert.AreEqual("Method3", fieldTemplate0.Name);
@@ -448,8 +424,8 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
 
             Assert.AreEqual(2, template.FieldTemplates.Count());
 
-            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
-            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0);
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1);
 
             // only public property and methods are shown (regardless of field inclusions)
             Assert.AreEqual("Method3", fieldTemplate0.Name);

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectGraphTypeTemplateTests.cs
@@ -421,5 +421,39 @@ namespace GraphQL.AspNet.Tests.Internal.Templating
             Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectThatInheritsNonExplicitMethodField.FieldOnObject)));
             Assert.IsTrue(template.FieldTemplates.Any(x => x.Value.InternalName == nameof(ObjectWithNonExplicitMethodField.FieldOnBaseObject)));
         }
+
+        [Test]
+        public void Parse_InternalMembers_AreNotTemplated()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(ObjectWithInternalFields));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count());
+
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
+
+            // the only public property and method (regardless of field inclusions)
+            Assert.AreEqual("Method3", fieldTemplate0.Name);
+            Assert.AreEqual("Field1", fieldTemplate1.Name);
+        }
+
+        [Test]
+        public void Parse_InternalInheritedMembers_AreNotTemplated()
+        {
+            var template = new ObjectGraphTypeTemplate(typeof(ObjectWithInternalInheritedFields));
+            template.Parse();
+            template.ValidateOrThrow();
+
+            Assert.AreEqual(2, template.FieldTemplates.Count());
+
+            var fieldTemplate0 = template.FieldTemplates.ElementAt(0).Value;
+            var fieldTemplate1 = template.FieldTemplates.ElementAt(1).Value;
+
+            // only public property and methods are shown (regardless of field inclusions)
+            Assert.AreEqual("Method3", fieldTemplate0.Name);
+            Assert.AreEqual("Field1", fieldTemplate1.Name);
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithInternalFields.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithInternalFields.cs
@@ -1,0 +1,66 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithInternalFields
+    {
+        [GraphField]
+        internal int Method1()
+        {
+            return 0;
+        }
+
+        internal int Method2()
+        {
+            return 0;
+        }
+
+        // not explicitly declared so shouldnt be added to a schema (with default config)
+        // but still should be templated
+        public int Method3()
+        {
+            return 0;
+        }
+
+        private int Method4()
+        {
+            return 0;
+        }
+
+        public static int Method5()
+        {
+            return 0;
+        }
+
+        public static int Method6()
+        {
+            return 0;
+        }
+
+        public int Field1 { get; set; }
+
+        // not explicitly decalred but internal, should be skipped
+        internal string Field2 { get; set; }
+
+        // explicitly declared but still internal, should be skipped
+        [GraphField]
+        internal string Field3 { get; set; }
+
+        private int Field4 { get; set; }
+
+        public static int Field5 { get; set; }
+
+        internal static int Field6 { get; set; }
+
+        private static int Field7 { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithInternalInheritedFields.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Internal/Templating/ObjectTypeTests/ObjectWithInternalInheritedFields.cs
@@ -7,12 +7,11 @@
 // License:  MIT
 // *************************************************************
 
-namespace GraphQL.AspNet.Tests.CommonHelpers
+namespace GraphQL.AspNet.Tests.Internal.Templating.ObjectTypeTests
 {
-    /// <summary>
-    /// A representation of a data object with no properties.
-    /// </summary>
-    public class EmptyObject
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithInternalInheritedFields : ObjectWithInternalFields
     {
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/GraphSchemaManagerTests.cs
@@ -375,7 +375,7 @@ namespace GraphQL.AspNet.Tests.Schemas
 
             // input type checks  (TwoPropertyObject, EmptyObject)
             Assert.AreEqual(2, schema.KnownTypes.Count(x => x.Kind == TypeKind.INPUT_OBJECT));
-            Assert.IsTrue(schema.KnownTypes.Contains(typeof(EmptyObject), TypeKind.INPUT_OBJECT));
+            Assert.IsTrue(schema.KnownTypes.Contains(typeof(SimpleObject), TypeKind.INPUT_OBJECT));
             Assert.IsTrue(schema.KnownTypes.Contains(typeof(TwoPropertyObject), TypeKind.INPUT_OBJECT));
 
             // general object types

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/GraphTypeCollectionTestData/SimpleDirective.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/GraphTypeCollectionTestData/SimpleDirective.cs
@@ -18,7 +18,7 @@ namespace GraphQL.AspNet.Tests.Schemas.GraphTypeCollectionTestData
     public class SimpleDirective : GraphDirective
     {
         [DirectiveLocations(DirectiveLocation.FIELD | DirectiveLocation.FRAGMENT_SPREAD | DirectiveLocation.INLINE_FRAGMENT)]
-        public Task<IGraphActionResult> Execute(object source)
+        public Task<IGraphActionResult> Execute()
         {
             return null;
         }

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/ControllerWithNoFieldInterfaceReturned.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/ControllerWithNoFieldInterfaceReturned.cs
@@ -7,14 +7,17 @@
 // License:  MIT
 // *************************************************************
 
-namespace GraphQL.AspNet.Tests.Internal.Templating.ControllerTestData
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
 {
     using GraphQL.AspNet.Attributes;
     using GraphQL.AspNet.Controllers;
-    using GraphQL.AspNet.Tests.Internal.Templating.DirectiveTestData;
 
-    [ApplyDirective(typeof(DirectiveWithArgs), 101, "controller arg")]
-    public class ControllerWithDirective : GraphController
+    public class ControllerWithNoFieldInterfaceReturned : GraphController
     {
+        [Query]
+        public INoFieldInterface QueryMethod1()
+        {
+            return null;
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/INoFieldInterface.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/INoFieldInterface.cs
@@ -1,0 +1,15 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    public interface INoFieldInterface
+    {
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/KitchenSinkController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/KitchenSinkController.cs
@@ -29,7 +29,7 @@ namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
         }
 
         [Query("TestAction2")]
-        public TwoPropertyObjectV2 TestActionMethod2(IEnumerable<EmptyObject> arg1, DateTime arg2)
+        public TwoPropertyObjectV2 TestActionMethod2(IEnumerable<SimpleObject> arg1, DateTime arg2)
         {
             return new TwoPropertyObjectV2();
         }

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/Object1ReferencesNoFieldInterface.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/Object1ReferencesNoFieldInterface.cs
@@ -1,0 +1,16 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    public class Object1ReferencesNoFieldInterface : INoFieldInterface
+    {
+        public int Field1 { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/Object2ReferencesNoFieldInterface.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/Object2ReferencesNoFieldInterface.cs
@@ -1,0 +1,16 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    public class Object2ReferencesNoFieldInterface : INoFieldInterface
+    {
+        public int Field1 { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/ObjectWithMethodOverloads.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Schemas/SchemaTestData/ObjectWithMethodOverloads.cs
@@ -1,0 +1,27 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Schemas.SchemaTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ObjectWithMethodOverloads
+    {
+        [GraphField]
+        public int Method1()
+        {
+            return 0;
+        }
+
+        public int Method1(string arg1)
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
* Added a specific error message when attempting to use a delegate (or `Func<>`, `Action<>`) as an argument to a field
* Improved the error messages for some argument type validation failures such that the the owner of the argument will now be named for easier identification.

## Specification Fixes
* Fixed a bug where non-leaf graph types (`OBJECT`, `INTERFACE`, `INPUT_OBJECT`) that declare no fields were allowed to be added to the schema in some circumstances. An exception will now be thrown at startup. [[§3.6](https://spec.graphql.org/October2021/#sec-Objects.Type-Validation)][[§3.7](https://spec.graphql.org/October2021/#sec-Interfaces.Type-Validation)][[§3.10](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-Validation)]

## Bug Fixes
* Added a rule to explicitly exclude any fields that accept, as an argument, or return as a value a `delegate`, `Func<>`, or `Action<>`. (i.e. anything that inherits from `Delegate`)
* Fixed a bug where an argument to a [Query], [Mutation] or Object field would not properly validate its type in some cases.
* Fixed a bug where a invalid method or property on an object, interface or controller would cause a startup exception even if that method or property would not have been added as a field on the schema.
* Fixed a bug where an object, interface or controller with overloaded methods would cause a startup exception even when only one or none of the methods would be included in the schema.
  * An error will still be thrown if multiple overloads are included in a graph type without unique field names.
* Fixed a bug where inherited methods or properties declared classes  `Object`  or `ValueType` may be parsed by the templating system in some cases.

## Templating Changes
* Altered the `ISchemaItemTemplate.ValidateOrThrow()` method to include a parameter for optionally validating children
* Shifted template validating into the Type Makers (previously part of templating). Schema Item Templates are no longer "pre-validated" and only undergo validation if they are being added to a schema.