### PR TITLE
Bug Fix: Logging During Authorization

### DIFF
--- a/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthenticationMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthenticationMiddleware.cs
@@ -6,6 +6,7 @@
 // --
 // License:  MIT
 // *************************************************************
+
 namespace GraphQL.AspNet.Middleware.SchemaItemSecurity.Components
 {
     using System;
@@ -47,22 +48,25 @@ namespace GraphQL.AspNet.Middleware.SchemaItemSecurity.Components
         /// <inheritdoc />
         public async Task InvokeAsync(SchemaItemSecurityChallengeContext context, GraphMiddlewareInvocationDelegate<SchemaItemSecurityChallengeContext> next, CancellationToken cancelToken = default)
         {
-            context.Logger?.SchemaItemAuthenticationChallenge(context);
-
             // only attempt an authentication
             // if no result is already deteremined and if no user has already been authenticated
-            IAuthenticationResult authenticationResult = null;
+            //
+            // if a piece of middleware has already set an authenticated user
+            // just skip this component.
             if (context.Result == null && context.AuthenticatedUser == null)
             {
+                context.Logger?.SchemaItemAuthenticationChallenge(context);
+                IAuthenticationResult authenticationResult = null;
+
                 ClaimsPrincipal user;
                 SchemaItemSecurityChallengeResult challengeResult;
 
                 (user, authenticationResult, challengeResult) = await this.AuthenticateUser(context, cancelToken);
                 context.AuthenticatedUser = user;
                 context.Result = challengeResult;
-            }
 
-            context.Logger?.SchemaItemAuthenticationChallengeResult(context, authenticationResult);
+                context.Logger?.SchemaItemAuthenticationChallengeResult(context, authenticationResult);
+            }
 
             await next.Invoke(context, cancelToken).ConfigureAwait(false);
         }

--- a/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthorizationMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthorizationMiddleware.cs
@@ -45,17 +45,17 @@ namespace GraphQL.AspNet.Middleware.SchemaItemSecurity.Components
         /// <returns>Task.</returns>
         public async Task InvokeAsync(SchemaItemSecurityChallengeContext context, GraphMiddlewareInvocationDelegate<SchemaItemSecurityChallengeContext> next, CancellationToken cancelToken = default)
         {
-            context.Logger?.SchemaItemAuthorizationChallenge(context);
-
             // a result may have been set by other middleware
             // in this auth pipeline, if a result is already determined just skip this step
             if (context.Result == null)
             {
+                context.Logger?.SchemaItemAuthorizationChallenge(context);
+
                 var result = await this.AuthorizeRequestAsync(context).ConfigureAwait(false);
                 context.Result = result ?? SchemaItemSecurityChallengeResult.Default();
-            }
 
-            context.Logger?.SchemaItemAuthorizationChallengeResult(context);
+                context.Logger?.SchemaItemAuthorizationChallengeResult(context);
+            }
 
             await next(context, cancelToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
* Fixed a bug where if a `ClaimsPrincipal` was set by a piece of middleware in the seucrity pipleine, the default authentication middleware would inadvertently log a blank warning message since it didn't perform the authentication itself.  The middleware now only logs messages if it attempts the authentication itself

* Fixed a bug where if a authorization challenge result was set by a piece of middleware in the security pipeline, the default authorization middleware would inadvertently log the challenge result , even when it did not determine this result itself.  This could result double logging in some use scenarios.  The default authorization component will now only log a challenge result it if produces the result itself.