### PR TITLE
Bug Fix:  Use Context ServiceProvider for AuthService Instance

### DIFF
--- a/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthorizationMiddleware.cs
+++ b/src/graphql-aspnet/Middleware/SchemaItemSecurity/Components/SchemaItemAuthorizationMiddleware.cs
@@ -59,7 +59,7 @@ namespace GraphQL.AspNet.Middleware.SchemaItemSecurity.Components
         {
             Validation.ThrowIfNull(context?.SecurityRequirements, nameof(SchemaItemSecurityChallengeContext.SecurityRequirements));
 
-            var authService = context.ServiceProvider.GetService<IAuthorizationService>();
+            var authService = context.ServiceProvider?.GetService<IAuthorizationService>();
             var claimsUser = context.AuthenticatedUser;
 
             // when there is nothing to enforce, just skip

--- a/src/unit-tests/graphql-aspnet-testframework/Interfaces/ITestAuthorizationBuilder.cs
+++ b/src/unit-tests/graphql-aspnet-testframework/Interfaces/ITestAuthorizationBuilder.cs
@@ -25,6 +25,15 @@ namespace GraphQL.AspNet.Tests.Framework.Interfaces
         ITestAuthorizationBuilder DisableAuthorization();
 
         /// <summary>
+        /// Force updates the <see cref="IAuthorizationService"/> served via DI
+        /// to the provided instance for all requests. This method has no effect if
+        /// <see cref="DisableAuthorization"/> is called.
+        /// </summary>
+        /// <param name="newService">The new authorization service to use.</param>
+        /// <returns>ITestAuthorizationBuilder.</returns>
+        ITestAuthorizationBuilder ReplaceAuthorizationService(IAuthorizationService newService);
+
+        /// <summary>
         /// Adds a simple new policy to the service based on a list of roles. When enforcing this policy
         /// the authorization service will require an authenticated user and
         /// check to see if the user belongs to any role in the list.

--- a/src/unit-tests/graphql-aspnet-tests/Middleware/SchemaItemAuthorizationMiddlewareTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Middleware/SchemaItemAuthorizationMiddlewareTests.cs
@@ -21,6 +21,8 @@ namespace GraphQL.AspNet.Tests.Middleware
     using GraphQL.AspNet.Security;
     using GraphQL.AspNet.Tests.Framework;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
     using NSubstitute;
     using NUnit.Framework;
 
@@ -68,6 +70,14 @@ namespace GraphQL.AspNet.Tests.Middleware
             }
 
             var builder = new TestServerBuilder();
+
+            // remove all auth service instances to limit to just
+            // those cases being tested
+            if (_authService == null)
+                builder.Authorization.DisableAuthorization();
+            else
+                builder.Authorization.ReplaceAuthorizationService(_authService);
+
             var buildUser = !string.IsNullOrWhiteSpace(_userName);
 
             // when null, do not authenticate the user
@@ -95,7 +105,7 @@ namespace GraphQL.AspNet.Tests.Middleware
             fieldSecurityContext.AuthenticatedUser = _user;
             fieldSecurityContext.SecurityRequirements = secRequirements;
 
-            var middleware = new SchemaItemAuthorizationMiddleware(_authService);
+            var middleware = new SchemaItemAuthorizationMiddleware();
             await middleware.InvokeAsync(fieldSecurityContext, this.EmptyNextDelegate);
 
             return fieldSecurityContext;


### PR DESCRIPTION
* Fixed a bug where `SchemaItemAuthorizationMiddleware` would resolve an `IAuthorizationService` instance at startup. It will now correctly resolve an instance per context invocation.
