### PR TITLE
Made message on "NotFound" Graph Result optional

### DIFF
--- a/src/graphql-aspnet/Controllers/GraphController_ActionResults.cs
+++ b/src/graphql-aspnet/Controllers/GraphController_ActionResults.cs
@@ -102,7 +102,7 @@ namespace GraphQL.AspNet.Controllers
         /// </summary>
         /// <param name="message">The message indicating what was not found.</param>
         /// <returns>IGraphActionResult.</returns>
-        protected virtual IGraphActionResult NotFound(string message)
+        protected virtual IGraphActionResult NotFound(string message = null)
         {
             return new RouteNotFoundGraphActionResult(message);
         }


### PR DESCRIPTION
* Made the error message on `this.NotFound(message)` optional.  
* A generic error message will be used when not supplied on the error response when not supplied by the caller.