### PR TITLE
Unit Tests: Field Ordering, AddGraphQL

### DIFF
--- a/src/graphql-aspnet/Configuration/SchemaInjectorCollection.cs
+++ b/src/graphql-aspnet/Configuration/SchemaInjectorCollection.cs
@@ -11,6 +11,7 @@ namespace GraphQL.AspNet.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using GraphQL.AspNet.Common;
     using GraphQL.AspNet.Interfaces.Configuration;
     using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,16 @@ namespace GraphQL.AspNet.Configuration
     /// </summary>
     public class SchemaInjectorCollection : Dictionary<Type, ISchemaInjector>, ISchemaInjectorCollection
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaInjectorCollection"/> class.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection this set is tracking against.</param>
+        public SchemaInjectorCollection(IServiceCollection serviceCollection)
+        {
+                this.ServiceCollection = Validation.ThrowIfNullOrReturn(serviceCollection, nameof(serviceCollection));
+        }
+
         /// <inheritdoc />
-        public IServiceCollection ServiceCollection { get; set; }
+        public IServiceCollection ServiceCollection { get; }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Configuration/ConfigurationSetupTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Configuration/ConfigurationSetupTests.cs
@@ -353,5 +353,25 @@ namespace GraphQL.AspNet.Tests.Configuration
             Assert.IsTrue(schema1.KnownTypes.Contains(typeof(Candle)));
             Assert.IsTrue(schema2.KnownTypes.Contains(typeof(Candle)));
         }
+
+        [Test]
+        public void AddGraphQL_AttemptingToInitializeSchemaASecondTime_ThrowsException()
+        {
+            var service1Collection = new ServiceCollection();
+            var service2Collection = new ServiceCollection();
+
+            service1Collection.AddGraphQL<CandleSchema>(options =>
+            {
+                options.AddGraphType<Candle>();
+            });
+
+            Assert.Throws<GraphTypeDeclarationException>(() =>
+            {
+                service1Collection.AddGraphQL<CandleSchema>(options =>
+                {
+                    options.AddGraphType<Candle>();
+                });
+            });
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-tests/Execution/FieldExecutionOrderTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/FieldExecutionOrderTests.cs
@@ -1,0 +1,107 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution
+{
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using GraphQL.AspNet.Tests.Execution.FieldExecutionorderTestData;
+    using GraphQL.AspNet.Tests.Framework;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class FieldExecutionOrderTests
+    {
+        private static readonly Regex _whitespace = new Regex(@"\s+");
+
+        [Test]
+        public async Task OrderTest()
+        {
+            var server = new TestServerBuilder()
+               .AddGraphQL(o =>
+               {
+                   o.AddType<HamburgerController>();
+                   o.AddType<ChickenController>();
+                   o.ResponseOptions.ExposeExceptions = true;
+               })
+               .Build();
+
+            var builder = server.CreateQueryContextBuilder()
+                .AddQueryText("query { " +
+                "      retrieveDefaultChickenMeal {" +
+                "            description " +
+                "            name " +
+                "            id" +
+                "      }" +
+                "      hamburger { " +
+                "           retrieveOtherHamburgerMeal {" +
+                "                 weight " +
+                "                 name " +
+                "                 id" +
+                "                 description " +
+                "           }" +
+                "      }" +
+                "      chicken { " +
+                "           retrieveOtherChickenMeal {" +
+                "                 id" +
+                "                 description " +
+                "                 name " +
+                "           }" +
+                "      }" +
+                "      retrieveDefaultHamburgerMeal {" +
+                "            id" +
+                "            description " +
+                "            name " +
+                "            weight " +
+                "      }" +
+                "}");
+
+            var expectedOutput =
+                @"{
+                  ""data"": {
+                    ""retrieveDefaultChickenMeal"": {
+                      ""description"": ""a top level chicken sandwich"",
+                      ""name"": ""Chicken Bacon Ranch"",
+                      ""id"": 5
+                    },
+                    ""hamburger"": {
+                      ""retrieveOtherHamburgerMeal"": {
+                        ""weight"": 1.3,
+                        ""name"": ""Tiny Hamburger"",
+                        ""id"": 5,
+                        ""description"": ""a nested Hamburger""
+                      }
+                    },
+                    ""chicken"": {
+                      ""retrieveOtherChickenMeal"": {
+                        ""id"": 5,
+                        ""description"": ""a nested chicken sandwich"",
+                        ""name"": ""Chicken Lettuce Tomato""
+                      }
+                    },
+                    ""retrieveDefaultHamburgerMeal"": {
+                      ""id"": 5,
+                      ""description"": ""a top level hamburger"",
+                      ""name"": ""Hamburger Supreme"",
+                      ""weight"": 2.5
+                    }
+                  }
+                }";
+
+            var result = await server.RenderResult(builder);
+
+            // must be an exact string with the exact character order for the data
+            // dont use json matching just to be sure
+            result = _whitespace.Replace(result, string.Empty);
+            expectedOutput = _whitespace.Replace(expectedOutput, string.Empty);
+
+            Assert.AreEqual(expectedOutput, result);
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/ChickenController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/ChickenController.cs
@@ -1,0 +1,44 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.FieldExecutionorderTestData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class ChickenController : GraphController
+    {
+        [QueryRoot]
+        public ChickenMeal RetrieveDefaultChickenMeal()
+        {
+            return new ChickenMeal()
+            {
+                Id = 5,
+                Name = "Chicken Bacon Ranch",
+                Description = "a top level chicken sandwich",
+            };
+        }
+
+        [Query]
+        public ChickenMeal RetrieveOtherChickenMeal()
+        {
+            return new ChickenMeal()
+            {
+                Id = 5,
+                Name = "Chicken Lettuce Tomato",
+                Description = "a nested chicken sandwich",
+            };
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/ChickenMeal.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/ChickenMeal.cs
@@ -1,0 +1,26 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.FieldExecutionorderTestData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class ChickenMeal
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/HamburgerController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/HamburgerController.cs
@@ -1,0 +1,41 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.FieldExecutionorderTestData
+{
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class HamburgerController : GraphController
+    {
+        [QueryRoot]
+        public HamburgerMeal RetrieveDefaultHamburgerMeal()
+        {
+            return new HamburgerMeal()
+            {
+                Id = 5,
+                Name = "Hamburger Supreme",
+                Weight = 2.5f,
+                Description = "a top level hamburger",
+            };
+        }
+
+        [Query]
+        public HamburgerMeal RetrieveOtherHamburgerMeal()
+        {
+            return new HamburgerMeal()
+            {
+                Id = 5,
+                Name = "Tiny Hamburger",
+                Weight = 1.3f,
+                Description = "a nested Hamburger",
+            };
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/HamburgerMeal.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/FieldExecutionorderTestData/HamburgerMeal.cs
@@ -1,0 +1,28 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.FieldExecutionorderTestData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class HamburgerMeal
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public float Weight { get; set; }
+
+        public string Description { get; set; }
+    }
+}


### PR DESCRIPTION
* Added a unit test to explicitly capture field ordering for a mixed root and nested controller action resolution
* Added a unit test to ensure no duplicate schema's per service collection for custom schemas

* fixed a minor potential race condition with schema injector registration and multiple service collections during setup