### PR TITLE
GET Request Body Support

### DIFF
--- a/src/ancillary-projects/starwars/starwars-common/GraphControllers/SearchController.cs
+++ b/src/ancillary-projects/starwars/starwars-common/GraphControllers/SearchController.cs
@@ -55,6 +55,8 @@ namespace GraphQL.AspNet.StarwarsAPI.Common.GraphControllers
             results.AddRange(ships);
             results.AddRange(droids);
 
+            results = results.Distinct().ToList();
+
             return this.Ok(results);
         }
     }


### PR DESCRIPTION
* Modified the parser to accept request bodies for GET or POST 
    * query string parameters still override body regardless of method
    
This should resolve a block preventing Postman from successfully completing a query as a GET request.