### PR TITLE
Bug Fix: Rule Validation Failure with multiple fragments and unknown Graph Types

### DIFF
--- a/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_3_2_FieldsOfIdenticalOutputMustHaveIdenticalSigs.cs
+++ b/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/FieldSelectionSteps/Rule_5_3_2_FieldsOfIdenticalOutputMustHaveIdenticalSigs.cs
@@ -246,22 +246,10 @@ namespace GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.Field
             if (rightField.Parent is IFieldSelectionSetDocumentPart fsdr)
                 rightSourceGraphType = fsdr.GraphType;
 
-            // neither should be null at this point
-            if (leftSourceGraphType == null)
-            {
-                throw new GraphExecutionException(
-                    $"Attempting to resolve specification rule {this.RuleNumber} resulted in " +
-                    "an invalid graph type comparrison. Unable to determine the target graph type of the " +
-                    $"existing field aliased as '{leftField.Alias.ToString()}'. Query was aborted.");
-            }
-
-            if (rightSourceGraphType == null)
-            {
-                throw new GraphExecutionException(
-                    $"Attempting to resolve specification rule {this.RuleNumber} resulted in " +
-                    "an invalid graph type comparrison. Unable to determine the target graph type of the " +
-                    $"new field aliased as '{rightField.Alias.ToString()}'. Query was aborted.");
-            }
+            // this rule does not apply when a graph type is not located or correctly
+            // scoped. Other rules (5.5.1.2 for instance) will catch this
+            if (leftSourceGraphType == null || rightSourceGraphType == null)
+                return true;
 
             // if the source graph types of either field "could" overlap at some point
             // then the two fields cannot safely co-exist.

--- a/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_2_InlineFragmentGraphTypeMustExistInTheSchema.cs
+++ b/src/graphql-aspnet/Execution/RulesEngine/RuleSets/DocumentValidation/QueryFragmentSteps/Rule_5_5_1_2_InlineFragmentGraphTypeMustExistInTheSchema.cs
@@ -28,7 +28,7 @@ namespace GraphQL.AspNet.Execution.RulesEngine.RuleSets.DocumentValidation.Query
             {
                 this.ValidationError(
                     context,
-                    $"No known graph type was found for the target fragment.");
+                    $"No known graph type was found for the target fragment (Target: {fragment.TargetGraphTypeName}).");
 
                 return false;
             }


### PR DESCRIPTION
Fixed issue where:
   * if a query has multiple fragment spreads in a field set
   * and those fragments could be mergeable
   * and one of the fragment's graph type is unresovable
   * an execution exception would be thrown instead of triggering rule 5.5.1.2

This query should trigger 5.5.1.2 but was crashing the query (resulting in a hard 500 response)
```graphql 
{
    search{
        ... on Human {
            id
            name
        }

        # Note incorrect casing on Droid
        ... on DRoid {
            id
            name
            __typename
        }    
    }
}

```

* The correct validation rule will now be triggered with appropriate messaging with this PR.

* Also updated the 5.5.1.2 error message for inline fragments to include the failed type name to add additional clarity.


Previous Catastrophic error message:
```
Response Code: 500
Unknown Internal Server Error
```

New Corrected Error Response
```json
{
  "errors": [
    {
      "message": "No known graph type was found for the target fragment (Target: 'DRoid').",
      "locations": [
        {
          "line": 7,
          "column": 5
        }
      ],
      "extensions": {
        "code": "INVALID_DOCUMENT",
        "severity": "CRITICAL",
        "metaData": {
          "Rule": "5.5.1.2",
          "RuleReference": "https://spec.graphql.org/October2021/#sec-Fragment-Spread-Type-Existence"
        }
      }
    }
  ]
}
```