### PR TITLE
BUG: Fixed a bug with early out ignoring of input fields

### DIFF
--- a/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
@@ -155,7 +155,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             if (propInfo == null)
                 return false;
 
-            if (propInfo.SingleAttributeOrDefault<GraphSkipAttribute>() != null)
+            if (propInfo.HasAttribute<GraphSkipAttribute>())
                 return false;
 
             if (Constants.IgnoredFieldNames.Contains(propInfo.Name))

--- a/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/InputObjectGraphTypeTemplate.cs
@@ -155,7 +155,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             if (propInfo == null)
                 return false;
 
-            if (propInfo.Attributes.SingleAttributeOrDefault<GraphSkipAttribute>() != null)
+            if (propInfo.SingleAttributeOrDefault<GraphSkipAttribute>() != null)
                 return false;
 
             if (Constants.IgnoredFieldNames.Contains(propInfo.Name))

--- a/src/unit-tests/graphql-aspnet-tests/Execution/GraphSkipSequencingTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/GraphSkipSequencingTests.cs
@@ -1,0 +1,45 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution
+{
+    using GraphQL.AspNet.Tests.Execution.TestData.GraphSkipSequencingTestData;
+    using GraphQL.AspNet.Tests.Framework;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class GraphSkipSequencingTests
+    {
+        [Test]
+        public void SkipFieldWithSameNameAsAnotherField_OBJECT()
+        {
+            using var restore = new GraphQLGlobalRestorePoint(true);
+
+            var server = new TestServerBuilder()
+                  .AddGraphQL(o =>
+                  {
+                      o.AddType<ClassWithRenamedField>(AspNet.Schemas.TypeSystem.TypeKind.OBJECT);
+                  })
+                  .Build();
+        }
+
+        [Test]
+        public void SkipFieldWithSameNameAsAnotherField_INPUTOBJECT()
+        {
+            using var restore = new GraphQLGlobalRestorePoint(true);
+
+            var server = new TestServerBuilder()
+                  .AddGraphQL(o =>
+                  {
+                      o.AddType<ClassWithRenamedField>(AspNet.Schemas.TypeSystem.TypeKind.INPUT_OBJECT);
+                  })
+                  .Build();
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/GraphSkipSequencingTestData/ClassWithRenamedField.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/GraphSkipSequencingTestData/ClassWithRenamedField.cs
@@ -1,0 +1,22 @@
+﻿// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.GraphSkipSequencingTestData
+{
+    using GraphQL.AspNet.Attributes;
+
+    public class ClassWithRenamedField
+    {
+        [GraphSkip]
+        public int RootNamedField { get; set; }
+
+        [GraphField("RootNamedField")]
+        public string ReNamedField { get; set; }
+    }
+}


### PR DESCRIPTION
* Fixed a bug where INPUT_OBJECT fields with `[GraphSkip]` are not being ignored as early as possible during templating causing some down stream effects in certain edge cases.