### PR TITLE
Bug: Fixed self-referencing input object lists

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -197,7 +197,7 @@ dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
 
-
-
 [*.{cs,vb}]
 dotnet_style_prefer_compound_assignment=true:suggestion
+
+file_header_template = *************************************************************\n project:  graphql-aspnet\n --\n repo: https://github.com/graphql-aspnet\n docs: https://graphql-aspnet.github.io\n --\n License:  MIT\n *************************************************************

--- a/src/graphql-aspnet/Internal/Resolvers/InputValueResolverMethodGenerator.cs
+++ b/src/graphql-aspnet/Internal/Resolvers/InputValueResolverMethodGenerator.cs
@@ -46,7 +46,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
         public IInputValueResolver CreateResolver(GraphTypeExpression typeExpression)
         {
             // used for variable definitions
-            return this.CreateResolver(typeExpression, null);
+            return this.CreateResolverInternal(typeExpression, null);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// <returns>IQueryInputValueResolver.</returns>
         public IInputValueResolver CreateResolver(IInputGraphField field)
         {
-            return this.CreateResolver(field.TypeExpression, field);
+            return this.CreateResolverInternal(field.TypeExpression, field);
         }
 
         /// <summary>
@@ -68,10 +68,10 @@ namespace GraphQL.AspNet.Internal.Resolvers
         /// <returns>IQueryInputValueResolver.</returns>
         public IInputValueResolver CreateResolver(IGraphArgument argument)
         {
-            return this.CreateResolver(argument.TypeExpression, argument);
+            return this.CreateResolverInternal(argument.TypeExpression, argument);
         }
 
-        private IInputValueResolver CreateResolver(GraphTypeExpression typeExpression, IDefaultValueSchemaItem defaultValueProvider)
+        private IInputValueResolver CreateResolverInternal(GraphTypeExpression typeExpression, IDefaultValueSchemaItem defaultValueProvider)
         {
             Validation.ThrowIfNull(typeExpression, nameof(typeExpression));
 
@@ -79,11 +79,17 @@ namespace GraphQL.AspNet.Internal.Resolvers
             if (graphType == null)
                 return null;
 
-            return this.CreateResolver(graphType, typeExpression, defaultValueProvider);
+            return this.CreateResolverInternal(graphType, typeExpression, defaultValueProvider);
         }
 
-        private IInputValueResolver CreateResolver(IGraphType graphType, GraphTypeExpression expression, IDefaultValueSchemaItem defaultValueProvider)
+        private IInputValueResolver CreateResolverInternal(IGraphType graphType, GraphTypeExpression expression, IDefaultValueSchemaItem defaultValueProvider, Dictionary<IInputObjectGraphType, IInputValueResolver> trackedComplexResolvers = null)
         {
+            // keep a list of complex value resolvers that were generated in this run
+            // to prevent infinite loops for self referencing objects
+            // all instnaces where a complex object needs to be resolved will use
+            // the same referenced resolver, scoped to this single argument that is being generated
+            trackedComplexResolvers = trackedComplexResolvers ?? new Dictionary<IInputObjectGraphType, IInputValueResolver>();
+
             // extract the core resolver for the input type being processed
             IInputValueResolver coreResolver = null;
             Type coreType = null;
@@ -101,7 +107,7 @@ namespace GraphQL.AspNet.Internal.Resolvers
             else if (graphType is IInputObjectGraphType inputType)
             {
                 coreType = _schema.KnownTypes.FindConcreteType(inputType);
-                coreResolver = this.CreateInputObjectResolver(inputType, coreType, defaultValueProvider);
+                coreResolver = this.CreateInputObjectResolver(inputType, coreType, defaultValueProvider, trackedComplexResolvers);
             }
 
             // wrap any list wrappers around core resolver according to the type expression
@@ -117,23 +123,22 @@ namespace GraphQL.AspNet.Internal.Resolvers
             return coreResolver;
         }
 
-        private IInputValueResolver CreateInputObjectResolver(IInputObjectGraphType inputType, Type type, IDefaultValueSchemaItem defaultValueProvider)
+        private IInputValueResolver CreateInputObjectResolver(
+            IInputObjectGraphType inputType,
+            Type type,
+            IDefaultValueSchemaItem defaultValueProvider,
+            Dictionary<IInputObjectGraphType, IInputValueResolver> trackedComplexResolvers)
         {
+            if (trackedComplexResolvers.TryGetValue(inputType, out var alreadyBuiltResolver))
+                return alreadyBuiltResolver;
+
             var inputObjectResolver = new InputObjectValueResolver(inputType, type, _schema, defaultValueProvider);
+            trackedComplexResolvers.Add(inputType, inputObjectResolver);
 
             foreach (var field in inputType.Fields)
             {
-                IInputValueResolver childResolver;
-                if (field.TypeExpression.TypeName == inputType.Name)
-                {
-                    childResolver = inputObjectResolver;
-                }
-                else
-                {
-                    var graphType = _schema.KnownTypes.FindGraphType(field.TypeExpression.TypeName);
-                    childResolver = this.CreateResolver(graphType, field.TypeExpression, field);
-                }
-
+                var graphType = _schema.KnownTypes.FindGraphType(field.TypeExpression.TypeName);
+                var childResolver = this.CreateResolverInternal(graphType, field.TypeExpression, field, trackedComplexResolvers);
                 inputObjectResolver.AddFieldResolver(field.Name, childResolver);
             }
 

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/SelfReferencingInputObject.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/SelfReferencingInputObject.cs
@@ -1,0 +1,20 @@
+﻿// *************************************************************
+//  project:  graphql-aspnet
+//  --
+//  repo: https://github.com/graphql-aspnet
+//  docs: https://graphql-aspnet.github.io
+//  --
+//  License:  MIT
+//  *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+
+    public class SelfReferencingInputObject
+    {
+        public string Name { get; set; }
+
+        public IEnumerable<SelfReferencingInputObject> Children { get; set; }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/SelfReferencingInputObjectController.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Execution/TestData/ExecutionPlanTestData/SelfReferencingInputObjectController.cs
@@ -1,0 +1,38 @@
+﻿// *************************************************************
+//  project:  graphql-aspnet
+//  --
+//  repo: https://github.com/graphql-aspnet
+//  docs: https://graphql-aspnet.github.io
+//  --
+//  License:  MIT
+//  *************************************************************
+
+namespace GraphQL.AspNet.Tests.Execution.TestData.ExecutionPlanTestData
+{
+    using System.Collections.Generic;
+    using GraphQL.AspNet.Attributes;
+    using GraphQL.AspNet.Controllers;
+
+    public class SelfReferencingInputObjectController : GraphController
+    {
+        [QueryRoot]
+        public int CountNestings(SelfReferencingInputObject item)
+        {
+            var i = 0;
+            var stack = new Stack<SelfReferencingInputObject>();
+            stack.Push(item);
+            while (stack.Count > 0)
+            {
+                var curItem = stack.Pop();
+                i++;
+                if (curItem.Children != null)
+                {
+                    foreach (var child in curItem.Children)
+                        stack.Push(child);
+                }
+            }
+
+            return i;
+        }
+    }
+}


### PR DESCRIPTION
* Fixed a bug such that when: 
   * An input object contains a field that is list of objects
   * AND the object type of that list is the input object type 
   * Then object would fail to generate and an exception would be thrown.


Self referencing input object lists should should as expected now.


Also updated editor config to natively support the expected file header