### PR TITLE
First go at exposing non-null references in as non-null in schema

### DIFF
--- a/src/graphql-aspnet/Internal/GraphValidation.cs
+++ b/src/graphql-aspnet/Internal/GraphValidation.cs
@@ -363,11 +363,13 @@ namespace GraphQL.AspNet.Internal
         /// Checks if the concrete type MUST be provided on the object graph or if it can be represented with 'null'.
         /// </summary>
         /// <param name="typeToCheck">The type to check.</param>
+        /// <param name="nullability">Nullability information from the property or method in question.</param>
         /// <returns><c>true</c> if not nullable, <c>false</c> otherwise.</returns>
-        public static bool IsNotNullable(Type typeToCheck)
+        public static bool IsNotNullable(Type typeToCheck, NullabilityInfo nullability = null)
         {
             // GraphId is the only "nullable" struct known to the system
-            return typeToCheck.IsValueType && !typeToCheck.IsNullableOfT();
+            return typeToCheck.IsValueType && !typeToCheck.IsNullableOfT() ||
+                nullability?.WriteState is NullabilityState.NotNull;
         }
     }
 }

--- a/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/GraphFieldTemplateBase.cs
@@ -84,7 +84,7 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
             }
 
             var objectType = GraphValidation.EliminateWrappersFromCoreType(this.DeclaredReturnType);
-            var typeExpression = GraphTypeExpression.FromType(this.DeclaredReturnType, this.DeclaredTypeWrappers);
+            var typeExpression = GraphTypeExpression.FromType(this.DeclaredReturnType, this.DeclaredTypeWrappers, this.NullabilityInfo);
             typeExpression = typeExpression.CloneTo(GraphTypeNames.ParseName(objectType, this.Parent.Kind));
 
             // ------------------------------------
@@ -333,6 +333,9 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         /// </summary>
         /// <returns>GraphRoutePath.</returns>
         protected abstract SchemaItemPath GenerateFieldPath();
+
+        ///
+        protected abstract NullabilityInfo NullabilityInfo { get; }
 
         /// <summary>
         /// Type extensions used as batch methods required a speceial input and output signature for the runtime

--- a/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplateBase.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/MethodGraphFieldTemplateBase.cs
@@ -99,6 +99,10 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
+        protected override NullabilityInfo NullabilityInfo =>
+            new NullabilityInfoContext().Create(this.Method.ReturnParameter);
+
+        /// <inheritdoc />
         public override string InternalFullName => $"{this.Parent?.InternalFullName}.{this.Method.Name}";
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Internal/TypeTemplates/PropertyGraphFieldTemplate.cs
+++ b/src/graphql-aspnet/Internal/TypeTemplates/PropertyGraphFieldTemplate.cs
@@ -98,6 +98,10 @@ namespace GraphQL.AspNet.Internal.TypeTemplates
         }
 
         /// <inheritdoc />
+        protected override NullabilityInfo NullabilityInfo =>
+            new NullabilityInfoContext().Create(this.Property);
+
+        /// <inheritdoc />
         public override Type DeclaredReturnType => this.Property.PropertyType;
 
         /// <inheritdoc />

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/NullableTemplateTests.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/NullableTemplateTests.cs
@@ -1,0 +1,141 @@
+// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers
+{
+    using System.Linq;
+    using GraphQL.AspNet.Tests.Engine.TypeMakers.TestData;
+    using GraphQL.AspNet.Tests.Framework;
+    using NUnit.Framework;
+
+    public class NullableTemplateTests : GraphTypeMakerTestBase
+    {
+        [Test]
+        public void InfersCorrectTypes_NonNullInteger()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var field = template.FieldTemplates.FirstOrDefault(it => it.Name == "NonNullInteger");
+
+            Assert.NotNull(field);
+            Assert.AreEqual("Int!", field.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NullableInteger()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var field = template.FieldTemplates.FirstOrDefault(it => it.Name == "NullableInteger");
+
+            Assert.NotNull(field);
+            Assert.AreEqual("Int", field.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NonNullString()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var field = template.FieldTemplates.FirstOrDefault(it => it.Name == "NonNullString");
+
+            Assert.NotNull(field);
+            Assert.AreEqual("String!", field.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NullableString()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var field = template.FieldTemplates.FirstOrDefault(it => it.Name == "NullableString");
+
+            Assert.NotNull(field);
+            Assert.AreEqual("String", field.TypeExpression.ToString());
+        }
+
+        [Test]
+        [Ignore("NullabilityInfo reflection of inner element is not available (May 2024)")]
+        public void InfersCorrectTypes_NonNullListNonNullItems()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NonNullListNonNullItems");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("[String!]!", nonNullString.TypeExpression.ToString());
+        }
+
+        [Test]
+        [Ignore("NullabilityInfo reflection of inner element is not available (May 2024)")]
+        public void InfersCorrectTypes_NullableListNonNullItems()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NullableListNonNullItems");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("[String!]", nonNullString.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NonNullListNullableItems()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NonNullListNullableItems");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("[String]!", nonNullString.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NullableListNullableItems()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NullableListNullableItems");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("[String]", nonNullString.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NonNullMethod()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NonNullMethod");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("String!", nonNullString.TypeExpression.ToString());
+        }
+
+        [Test]
+        public void InfersCorrectTypes_NullableMethod()
+        {
+            var server = new TestServerBuilder().Build();
+            var template = GraphQLTemplateHelper.CreateObjectTemplate<NullableContextObject>();
+
+            var nonNullString = template.FieldTemplates.FirstOrDefault(it => it.Name == "NullableMethod");
+
+            Assert.NotNull(nonNullString);
+            Assert.AreEqual("String", nonNullString.TypeExpression.ToString());
+        }
+    }
+}

--- a/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/NullableContextObject.cs
+++ b/src/unit-tests/graphql-aspnet-tests/Engine/TypeMakers/TestData/NullableContextObject.cs
@@ -1,0 +1,43 @@
+// *************************************************************
+// project:  graphql-aspnet
+// --
+// repo: https://github.com/graphql-aspnet
+// docs: https://graphql-aspnet.github.io
+// --
+// License:  MIT
+// *************************************************************
+
+// Enabling the nullable reference feature makes the type engine expose reference types
+// like String and List as non-null, unless annotated with the nullable (?) operator.
+#nullable enable
+
+namespace GraphQL.AspNet.Tests.Engine.TypeMakers.TestData
+{
+    using GraphQL.AspNet.Attributes;
+    using System.Collections.Generic;
+
+    public class NullableContextObject
+    {
+        public required int NonNullInteger { get; set; }
+
+        public int? NullableInteger { get; set; }
+
+        public required string NonNullString { get; set; }
+
+        public string? NullableString { get; set; }
+
+        public required List<string> NonNullListNonNullItems { get; set; }
+
+        public List<string>? NullableListNonNullItems { get; set; }
+
+        public required List<string?> NonNullListNullableItems { get; set; }
+
+        public List<string?>? NullableListNullableItems { get; set; }
+
+        [GraphField]
+        public string NonNullMethod() => "";
+
+        [GraphField]
+        public string? NullableMethod() => "";
+    }
+}


### PR DESCRIPTION
@kevin-carroll If you have time, please have a look at this attempt to support nullable references ( see #157 )

Of course, I'm not super-familiar with the codebase, so I don't know if this is an appropriate way to do this. It probably can be a breaking change for someone that is using nullable references, since it will change their schema. So maybe this could be considered as an opt-in feature?

I came across a couple of obstacles:

Apparently reflection of element types inside a generic collection, such as `List<string>` vs `List<string?>`, is not possible. I did some googling, and it seems like it can't be done.

The tests fail in net6.0. I think it's only the test that I added that is not supported. The library still works, except you might not actually be able to take advantage of this feature, unless you upgrade the framework.