### PR TITLE
Package Upgrade: Bump System.Text.Json

### DIFF
--- a/src/library-common.props
+++ b/src/library-common.props
@@ -55,10 +55,10 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
 
     <!-- Transitive package increments to account for MS reported vulnerabilities -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
@@ -68,7 +68,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />


### PR DESCRIPTION
Bumped minimum required versions on several dependencies based on a [security advisory](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) from Microsoft.

* `System.Text.Json` :  `4.6.0` => `8.0.4`
* `System.Text.Encodings.Web`:  `4.7.2` => `8.0.0` 
* `Microsoft.Bcl.AsyncInterfaces`: `1.0.0` => `8.0.0`