### PR TITLE
Bug: Subscription Message Serialziation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build:
     name:  Sanity Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nuget-deployment.yml
+++ b/.github/workflows/nuget-deployment.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   deployment:
     name:  Pack & Deploy    
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/src/ancillary-projects/starwars/starwars-api90/Properties/launchSettings.json
+++ b/src/ancillary-projects/starwars/starwars-api90/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "StarWars: .NET 8": {
+    "StarWars: .NET 9": {
       "commandName": "Project",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxy.cs
@@ -94,6 +94,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlTransportWs
             _serializerOptions.Converters.Add(new GqltwsServerDataMessageConverter(schema, responseWriter));
             _serializerOptions.Converters.Add(new GqltwsServerCompleteMessageConverter());
             _serializerOptions.Converters.Add(new GqltwsServerErrorMessageConverter(schema));
+            _serializerOptions.Converters.Add(new GqltwsMessageConverter());
         }
 
         /// <summary>

--- a/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
+++ b/src/graphql-aspnet-subscriptions/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxy.cs
@@ -93,6 +93,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
             _serializeOptions.Converters.Add(new GraphqlWsLegacyServerDataMessageConverter(schema, responseWriter));
             _serializeOptions.Converters.Add(new GraphqlWsLegacyServerCompleteMessageConverter());
             _serializeOptions.Converters.Add(new GraphqlWsLegacyServerErrorMessageConverter(schema));
+            _serializeOptions.Converters.Add(new GraphqlWsLegacyMessageConverter());
         }
 
         /// <inheritdoc />
@@ -305,7 +306,7 @@ namespace GraphQL.AspNet.SubscriptionServer.Protocols.GraphqlWsLegacy
         /// <inheritdoc />
         protected override async Task ExecuteKeepAliveAsync(CancellationToken cancelToken = default)
         {
-            await this.SendMessageAsync(new GraphqlWsLegacyKeepAliveOperationMessage());
+            await this.SendMessageAsync(new GraphqlWsLegacyKeepAliveOperationMessage(), cancelToken);
         }
 
         /// <inheritdoc />

--- a/src/graphql-aspnet/Common/TimerAsync.cs
+++ b/src/graphql-aspnet/Common/TimerAsync.cs
@@ -90,7 +90,8 @@ namespace GraphQL.AspNet.Common
             }
             finally
             {
-                _semaphore.Release();
+                if (!_disposed)
+                    _semaphore.Release();
             }
         }
 
@@ -121,7 +122,8 @@ namespace GraphQL.AspNet.Common
             finally
             {
                 this.IsRunning = false;
-                _semaphore.Release();
+                if (!_disposed)
+                    _semaphore.Release();
             }
         }
 

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxyTests.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlTransportWs/GqltwsClientProxyTests.cs
@@ -746,5 +746,23 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlTransportWs
             connection.AssertServerClosedConnection((ConnectionCloseStatus)GqltwsConstants.CustomCloseEventIds.InvalidMessageType);
             graphqlWsClient.Dispose();
         }
+
+        [Test]
+        public async Task SendConnectionInitMessage_RespondsWithCorrectAckMessage()
+        {
+            using var restorePoint = new GraphQLGlobalSubscriptionRestorePoint();
+            (var socketClient, var client, var router) = this.CreateConnection();
+
+            socketClient.QueueClientMessage(new GqltwsClientConnectionInitMessage());
+            socketClient.QueueConnectionClosedByClient();
+
+            await client.StartConnectionAsync();
+
+            var rawMessageData = socketClient.AssertGqltwsResponse(GqltwsMessageType.CONNECTION_ACK);
+            socketClient.AssertClientClosedConnection();
+
+            var expectedData = "{ \"type\": \"connection_ack\" }";
+            CommonAssertions.AreEqualJsonStrings(expectedData, rawMessageData);
+        }
     }
 }

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientAsserts.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientAsserts.cs
@@ -25,12 +25,13 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
         /// <param name="connection">The connection.</param>
         /// <param name="type">The type of message to check for.</param>
         /// <param name="dequeue">if true, the message is removed from the queue.</param>
-        internal static void AssertGraphqlWsLegacyResponse(
+        /// <returns>The raw string data (usually json formatted) of the message data recevied by the connection proxy </returns>
+        internal static string AssertGraphqlWsLegacyResponse(
             this MockClientConnection connection,
             GraphqlWsLegacyMessageType type,
             bool dequeue = true)
         {
-            connection.AssertGraphqlWsLegacyResponse(type, null, false, null, false, dequeue);
+            return connection.AssertGraphqlWsLegacyResponse(type, null, false, null, false, dequeue);
         }
 
         /// <summary>
@@ -40,13 +41,14 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
         /// <param name="type">The type of message to check for.</param>
         /// <param name="id">The id returned by the server, if supplied.</param>
         /// <param name="dequeue">if true, the message is removed from the queue.</param>
-        internal static void AssertGraphqlWsLegacyResponse(
+        /// <returns>The raw string data (usually json formatted) of the message data recevied by the connection proxy </returns>
+        internal static string AssertGraphqlWsLegacyResponse(
             this MockClientConnection connection,
             GraphqlWsLegacyMessageType type,
             string id,
             bool dequeue = true)
         {
-            connection.AssertGraphqlWsLegacyResponse(type, id, true, null, false, dequeue);
+            return connection.AssertGraphqlWsLegacyResponse(type, id, true, null, false, dequeue);
         }
 
         /// <summary>
@@ -58,17 +60,18 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
         /// <param name="id">The expected identifier of the subscription that rendered the data.</param>
         /// <param name="expectedPayloadJson">The expected payload of the message, converted to a json string.</param>
         /// <param name="dequeue">if set to <c>true</c> if the message should be removed from the queue.</param>
-        internal static void AssertGraphqlWsLegacyResponse(
+        /// <returns>The raw string data (usually json formatted) of the message data recevied by the connection proxy </returns>
+        internal static string AssertGraphqlWsLegacyResponse(
             this MockClientConnection connection,
             GraphqlWsLegacyMessageType type,
             string id,
             string expectedPayloadJson,
             bool dequeue = true)
         {
-            connection.AssertGraphqlWsLegacyResponse(type, id, true, expectedPayloadJson, true, dequeue);
+            return connection.AssertGraphqlWsLegacyResponse(type, id, true, expectedPayloadJson, true, dequeue);
         }
 
-        private static void AssertGraphqlWsLegacyResponse(
+        private static string AssertGraphqlWsLegacyResponse(
             this MockClientConnection connection,
             GraphqlWsLegacyMessageType type,
             string id,
@@ -81,14 +84,14 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
                 Assert.Fail("No messages queued.");
 
             var message = dequeue ? connection.DequeueNextReceivedMessage() : connection.PeekNextReceivedMessage();
-            var str = Encoding.UTF8.GetString(message.Data);
+            var rawData = Encoding.UTF8.GetString(message.Data);
 
             var options = new JsonSerializerOptions();
             options.PropertyNameCaseInsensitive = true;
             options.AllowTrailingCommas = true;
             options.Converters.Add(new GraphqlWsLegacyResponseMessageConverter());
 
-            var convertedMessage = JsonSerializer.Deserialize<GraphqlWsLegacyResponseMessage>(str, options);
+            var convertedMessage = JsonSerializer.Deserialize<GraphqlWsLegacyResponseMessage>(rawData, options);
 
             Assert.IsNotNull(convertedMessage, "Could not deserialized response message");
             Assert.AreEqual(type, convertedMessage.Type, $"Expected message type of {type.ToString()} but got {convertedMessage.Type.ToString()}");
@@ -103,6 +106,8 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
 
             if (compareId)
                 Assert.AreEqual(id, convertedMessage.Id);
+
+            return rawData;
         }
     }
 }

--- a/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxyTests.cs
+++ b/src/unit-tests/graphql-aspnet-subscriptions-tests/SubscriptionServer/Protocols/GraphqlWsLegacy/GraphqlWsLegacyClientProxyTests.cs
@@ -501,5 +501,23 @@ namespace GraphQL.AspNet.Tests.SubscriptionServer.Protocols.GraphqlWsLegacy
             socketClient.AssertGraphqlWsLegacyResponse(GraphqlWsLegacyMessageType.ERROR);
             socketClient.AssertClientClosedConnection();
         }
+
+        [Test]
+        public async Task SendConnectionInitMessage_RespondsWithCorrectAckMessage()
+        {
+            using var restorePoint = new GraphQLGlobalSubscriptionRestorePoint();
+            (var socketClient, var client, var router) = this.CreateConnection();
+
+            socketClient.QueueClientMessage(new GraphqlWsLegacyClientConnectionInitMessage());
+            socketClient.QueueConnectionClosedByClient();
+
+            await client.StartConnectionAsync();
+
+            var rawMessageData = socketClient.AssertGraphqlWsLegacyResponse(GraphqlWsLegacyMessageType.CONNECTION_ACK);
+            socketClient.AssertClientClosedConnection();
+
+            var expectedData = "{ \"type\": \"connection_ack\" }";
+            CommonAssertions.AreEqualJsonStrings(expectedData, rawMessageData);
+        }
     }
 }


### PR DESCRIPTION
# Bug Fix - Subscription Messages
* Fixed an bug with Id values being transmitted with a null value on non-specialized subscription messages.
* Added unit tests to ensure non-existent id value on ACK messages for both protocols.


## Infrastructure
* Advanced github action build version of Ubuntu to latest (24.04)



Closes: #168 